### PR TITLE
fix: 安装脚本改进——profile 清理/路径校验/PS1 include 对齐/README 修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cp -r agents ~/.claude/skills/awesome-novel/
 cp -r skills ~/.claude/skills/awesome-novel/
 cp -r templates ~/.claude/skills/awesome-novel/
 cp -r knowledge ~/.claude/skills/awesome-novel/
-cp -r memory ~/.claude/skills/awesome-novel/
+[ -d memory ] && cp -r memory ~/.claude/skills/awesome-novel/
 cp -r tools ~/.claude/skills/awesome-novel/
 cp SKILL.md ~/.claude/skills/awesome-novel/
 echo "安装完成!"

--- a/agents/prompt-crafter.md
+++ b/agents/prompt-crafter.md
@@ -123,15 +123,16 @@ knowledge:
 
   LOAD SKILL:
     加载 skills/prompt-audit.md
-    执行全流程：维度 A(场景-技法覆盖率) → B(知识点溯源) → C(可执行性) → D(四步转化完整性) → E(层间一致性)
+    执行全流程：维度 A(技法覆盖率) → B(知识点溯源) → C(可执行性) → D(四步转化完整性) → E(层间一致性)
+    （审计仅检查已写入 prompt.md 的内容，不重新读取 scene-craft 源文件）
 
   OBSERVE:
-    读什么？← 已写入的 prompts/vol-{N}-ch-{M}-prompt.md + chapters/ + .claude/knowledge/scene-craft/ + settings/genre-setting.md
+    读什么？← 已写入的 prompts/vol-{N}-ch-{M}-prompt.md（scene-craft 方法论已在组装阶段读过并注入，审计时不重复加载）
     工具：五(Read)
 
   THINK:
     逐项评估五个审计维度
-    对照原始 scene-craft 方法论检查 输出·写作规范 的落地质量
+    检查 prompt 输出·写作规范 中注入的技法是否完整、是否经过四步转化、是否可执行
     约束：核心原则——你不是 prompt-crafter，不维护不解释，只找问题
 
   ACT:

--- a/install.ps1
+++ b/install.ps1
@@ -16,7 +16,7 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code", "hermes", "openclaw")]
+    [ValidateSet("claude-code", "hermes", "openclaw", "deepseek-tui")]
     [string]$Platform
 )
 
@@ -32,19 +32,33 @@ switch ($Platform) {
     "openclaw" {
         $DEST_DIR = "$HOME_DIR\.openclaw\skills\awesome-novel"
     }
+    "deepseek-tui" {
+        $DEST_DIR = "$HOME_DIR\.deepseek\skills\awesome-novel"
+    }
 }
 
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Write-Host "安装到: $DEST_DIR"
 
-# 全量覆盖
+# 创建目录，已存在则清空
 Remove-Item -Recurse -Force $DEST_DIR -ErrorAction SilentlyContinue
-Copy-Item -Recurse "$SCRIPT_DIR" "$DEST_DIR"
+New-Item -ItemType Directory -Force -Path $DEST_DIR | Out-Null
 
-# 清理不需要的文件
-Remove-Item -Recurse -Force "$DEST_DIR\.git" -ErrorAction SilentlyContinue
-Remove-Item -Recurse -Force "$DEST_DIR\.claude" -ErrorAction SilentlyContinue
-Remove-Item -Recurse -Force "$DEST_DIR\docs" -ErrorAction SilentlyContinue
+# 显式 include 列表，与 install.sh 保持一致
+$INCLUDES = @("SKILL.md", "agents", "skills", "knowledge", "templates", "tools")
+
+foreach ($item in $INCLUDES) {
+    $src = Join-Path $SCRIPT_DIR $item
+    if (Test-Path $src) {
+        Copy-Item -Recurse $src "$DEST_DIR\"
+    }
+}
+
+# memory/ 含 writer-style 等静态参考素材（可选）
+$memoryDir = Join-Path $SCRIPT_DIR "memory"
+if (Test-Path $memoryDir) {
+    Copy-Item -Recurse $memoryDir "$DEST_DIR\"
+}
 
 Write-Host "安装完成!"

--- a/install.ps1
+++ b/install.ps1
@@ -16,26 +16,11 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code", "hermes", "openclaw", "deepseek-tui")]
+    [ValidateSet("claude-code")]
     [string]$Platform
 )
 
-$HOME_DIR = $env:USERPROFILE
-
-switch ($Platform) {
-    "claude-code" {
-        $DEST_DIR = "$HOME_DIR\.claude\skills\awesome-novel"
-    }
-    "hermes" {
-        $DEST_DIR = "$HOME_DIR\.hermes\skills\awesome-novel"
-    }
-    "openclaw" {
-        $DEST_DIR = "$HOME_DIR\.openclaw\skills\awesome-novel"
-    }
-    "deepseek-tui" {
-        $DEST_DIR = "$HOME_DIR\.deepseek\skills\awesome-novel"
-    }
-}
+$DEST_DIR = "$env:USERPROFILE\.claude\skills\awesome-novel"
 
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 

--- a/install.sh
+++ b/install.sh
@@ -56,16 +56,33 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "安装到: $DEST"
 export NOVEL_SKILL_HOME="$DEST"
 
-# 将 NOVEL_SKILL_HOME 写入 profile 文件，确保所有 shell 类型可用
-for profile_file in "$HOME/.profile" "$HOME/.bashrc"; do
-    if ! grep -q "export NOVEL_SKILL_HOME" "$profile_file" 2>/dev/null; then
-        echo "export NOVEL_SKILL_HOME=\"$DEST\"" >> "$profile_file"
-        echo "已添加 NOVEL_SKILL_HOME=$DEST 到 $profile_file"
-    fi
+# 将 NOVEL_SKILL_HOME 写入 profile 文件，支持 bash/zsh/fish
+# 先清理旧的 NOVEL_SKILL_HOME 行，避免重装产生重复
+for profile_file in "$HOME/.profile" "$HOME/.bashrc" "$HOME/.zshrc"; do
+    [ -f "$profile_file" ] || continue
+    # 用临时文件清理旧行再写新行
+    tmpfile=$(mktemp)
+    grep -v "export NOVEL_SKILL_HOME" "$profile_file" > "$tmpfile" 2>/dev/null || true
+    echo "export NOVEL_SKILL_HOME=\"$DEST\"" >> "$tmpfile"
+    mv "$tmpfile" "$profile_file"
+    echo "已更新 NOVEL_SKILL_HOME=$DEST 到 $profile_file"
 done
 
-# 安全检查：DEST 不能为空、不能是根目录、路径中必须包含 awesome-novel
-if [[ -z "$DEST" || "$DEST" == "/" || "$DEST" != *awesome-novel* ]]; then
+# fish shell 支持（如果存在）
+if command -v fish &>/dev/null; then
+    fish_conf="$HOME/.config/fish/config.fish"
+    if [ -f "$fish_conf" ]; then
+        tmpfile=$(mktemp)
+        grep -v "set -gx NOVEL_SKILL_HOME" "$fish_conf" > "$tmpfile" 2>/dev/null || true
+        echo "set -gx NOVEL_SKILL_HOME \"$DEST\"" >> "$tmpfile"
+        mv "$tmpfile" "$fish_conf"
+        echo "已更新 NOVEL_SKILL_HOME=$DEST 到 $fish_conf"
+    fi
+fi
+
+# 安全检查：DEST 必须是以 $HOME 开头的 skills/awesome-novel 路径
+CANONICAL_DEST="$(cd "$(dirname "$DEST")" 2>/dev/null && pwd)/$(basename "$DEST")"
+if [[ -z "$DEST" || "$DEST" == "/" || "$CANONICAL_DEST" != "$HOME/."*"/skills/awesome-novel" ]]; then
     echo "错误：安装目标路径异常 ($DEST)，中止。"
     exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ for profile_file in "$HOME/.profile" "$HOME/.bashrc" "$HOME/.zshrc"; do
     tmpfile=$(mktemp)
     grep -v "export NOVEL_SKILL_HOME" "$profile_file" > "$tmpfile" 2>/dev/null || true
     echo "export NOVEL_SKILL_HOME=\"$DEST\"" >> "$tmpfile"
+    chmod 644 "$tmpfile"
     mv "$tmpfile" "$profile_file"
     echo "已更新 NOVEL_SKILL_HOME=$DEST 到 $profile_file"
 done
@@ -75,6 +76,7 @@ if command -v fish &>/dev/null; then
         tmpfile=$(mktemp)
         grep -v "set -gx NOVEL_SKILL_HOME" "$fish_conf" > "$tmpfile" 2>/dev/null || true
         echo "set -gx NOVEL_SKILL_HOME \"$DEST\"" >> "$tmpfile"
+        chmod 644 "$tmpfile"
         mv "$tmpfile" "$fish_conf"
         echo "已更新 NOVEL_SKILL_HOME=$DEST 到 $fish_conf"
     fi


### PR DESCRIPTION
Closes #73
Ref: #77

### 改动清单

| # | 问题 | 修复 |
|---|------|------|
| 1 | install.sh 写 profile 不清理旧行，切换平台产生重复 export；缺 zsh/fish 支持 | 改为先清理旧行再写新行；支持 .zshrc 和 fish config.fish |
| 2 | install.ps1 全量拷贝再删，比 install.sh 多带了 LICENSE/README/reference 等文件 | 改为 include list 方式（SKILL.md/agents/skills/knowledge/templates/tools）对齐 install.sh；仅保留 claude-code |
| 3 | install.sh 路径校验只检查字符串包含 awesome-novel | 加 $HOME 前缀锁，确保路径以 $HOME/.{x}/skills/awesome-novel 开头 |
| 4 | README 手动安装段的 `cp -r memory` 因目录不存在报错 | 改为 `[ -d memory ] && cp -r memory` 可选拷贝 |
| 5 | prompt-crafter 审计轮重复读取 scene-craft | 审计轮只检查已写入 prompt.md 的内容，不再重新加载 scene-craft 源文件