### PR TITLE
feat: 新增 Codex 平台支持（Closes #59）

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,6 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,6 +37,7 @@ jobs:
 
   deploy:
     needs: lint
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,6 +31,8 @@ jobs:
         run: python tools/check-agents.py
       - name: Check rule conflicts
         run: python tools/check-conflicts.py
+      - name: Run platform tests
+        run: python tools/test_platforms.py
 
   deploy:
     needs: lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Repository Guidelines
+
+## 项目结构与模块组织
+
+- `agents/` — 8 个写作 agent 定义（novel-agent 总指挥 + 7 个子 agent），Markdown + frontmatter。
+- `skills/` — 各 agent 的 SOP 指令，按 `{环节}-{动作}.md` 命名。
+- `knowledge/` — 知识库：`genre-example/` 题材档案、`anti-ai/` 反 AI 规则、`format-specs/` 格式规范、`{plot|scene|character|title}-craft/` 创作方法论。
+- `templates/` — 项目初始化模板（`settings/`、`migration/` 旧项目迁移）。
+- `tools/` — Python 工具：`init.py`（初始化）、`sync-project.py`（同步）、`platforms.py`（平台适配）、`check-agents.py` / `check-conflicts.py`（静态检查）、`test_platforms.py`（测试）。
+- 根目录：`README.md` / `README-en.md`、`SKILL.md`、`skill.json`、`ARCHITECTURE.md`、`CONTRIBUTING.md`、`install.sh` / `install.ps1`；图片素材在 `reference/images/`。
+
+## 构建、测试与开发命令
+
+无构建步骤。Python 主体仅用标准库；`--platform opencode|reasonix|codex` 的 agent 转换需要 pyyaml（见 `tools/requirements.txt`，CI 自动安装）：
+
+- `python tools/init.py <项目路径> [--genre N] [--platform claude|opencode|reasonix|codex]` — 初始化小说项目骨架
+- `python tools/sync-project.py <项目路径> --check` — 检查项目是否需要同步（0=最新，1=有更新，2=无效）
+- `python tools/test_platforms.py` — 运行测试（退出码 0=通过）
+- `python tools/check-agents.py` — 校验 agent frontmatter 引用路径
+- `python tools/check-conflicts.py` — 检查反 AI 规则阈值冲突
+- `python -m py_compile tools/*.py` — 语法检查
+
+CI：`.github/workflows/static.yml`，push main 时运行语法/agent/规则检查 + 平台测试套件，并部署 GitHub Pages。
+
+## 编码风格与命名约定
+
+- Python：snake_case 文件名；仅标准库；入口脚本顶部用 `reconfigure(encoding="utf-8")` 防 Windows 中文乱码；docstring 写明用法与退出码。
+- Markdown：中文正文、UTF-8；frontmatter 引用路径相对仓库根解析。
+- 命名：agent 定义 `{role}-agent.md`；章节 `vol-{N}-ch-{M}.md`、卷纲 `volume-{N}.md`；知识文件按 `knowledge/<分类>/<题材或主题>.md` 组织。
+- 改动贴合项目定位（AI 辅助小说创作），不引入无关功能或依赖。
+
+## 测试指南
+
+- 无第三方测试框架；`tools/test_platforms.py` 自写断言，stdout 打印 `ok/FAIL`，非 0 退出码表示失败。
+- 测试函数以 `test_` 开头；E2E 用临时目录验证 init/sync 在 claude/opencode/reasonix/codex 四平台的输出。
+- 涉及 agent 定义跑 `check-agents.py`，涉及反 AI 规则跑 `check-conflicts.py`。
+- 行为变更遵循先红后绿：先加失败用例，再实现（见 `docs/superpowers/` 计划）。
+
+## 提交与 PR 指南
+
+- 提交信息遵循 Conventional Commits + 中文描述：`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `chore:`，如 `fix: sync-project --platform 值守卫防吞 --check`。
+- 发版时 `chore: bump version to vX.Y.Z`，同步更新 `VERSION` 与 `docs/releasenote-*`。
+- PR：从 main 新建分支，禁止直接改 main；单个 PR 聚焦一项改动并关联 issue；提交前至少在一种 AI 终端实测（claude/opencode/reasonix/codex）。
+
+## 安全与配置提示
+
+- 平台适配逻辑集中在 `tools/platforms.py`，新增平台或修改目录约定时先改这里，再同步 init/sync。
+- 遵守 GPLv3，不提交无版权素材、侵权文案或用户小说内容。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,6 +183,7 @@ tools/           # init.py（初始化）、sync-project.py（同步更新）
 
 - **Claude Code**：init.py 部署 agent 定义到 `.claude/agents/`，知识到 `.claude/knowledge/`，建 `.claude/memory/` 动态记忆桩
 - **OpenCode**：init.py 同时部署到 `.opencode/agents/`，OpenCode 自动发现 `@novel-agent` 等
+- **Codex**：init.py 部署 8 个自定义 agent 为 `.codex/agents/*.toml`（TOML 转换产物，引用改写为 `.codex/knowledge|memory`），独立工具为 `.codex/skills/<name>/SKILL.md`；novel-agent 用 `spawn_agent` 调度子 agent
 - **安装**：`install.sh` / `install.ps1` 将 skill 装到用户级 skills 目录
 
 ---

--- a/README-en.md
+++ b/README-en.md
@@ -1,12 +1,13 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>Write Novels with Claude Code / OpenCode / Reasonix</em>
+  <em>Write Novels with Claude Code / OpenCode / Reasonix / Codex</em>
 </p>
 
 <p align="center">
   <a href="https://docs.anthropic.com/en/docs/claude-code/overview"><img src="https://img.shields.io/badge/Claude%20Code-%E2%9C%93%20%E6%94%AF%E6%8C%81-6B46C1?style=flat-square" alt="Claude Code"></a>
   <a href="https://github.com/sglaboratory/opencode"><img src="https://img.shields.io/badge/OpenCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-4A90D9?style=flat-square" alt="OpenCode"></a>
   <img src="https://img.shields.io/badge/Reasonix-%E2%9C%93%20%E6%94%AF%E6%8C%81-16A34A?style=flat-square" alt="Reasonix">
+  <a href="#codex-integration"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
 </p>
@@ -46,7 +47,7 @@ Let AI be your novel writing partner, from world-building to character developme
 
 ## What You Need
 
-- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), or Reasonix installed
+- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, or **Codex** installed
 - About 1 minute to install
 
 ## Installation
@@ -71,6 +72,16 @@ Reasonix skills are deployed **per-project** (into `.reasonix/skills/`), not glo
 git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill
 python tools/init.py <novel-project-path> --platform reasonix
 cd <novel-project-path> && reasonix code
+```
+
+**Codex:**
+
+The Codex skill is installed **user-level** (`~/.codex/skills/awesome-novel/`), while agents/skills/knowledge/memory are deployed **project-level** into `.codex/` at init time:
+
+```bash
+git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
+python tools/init.py <novel-project-path> --platform codex
+cd <novel-project-path>  # then call @novel-agent in Codex to start writing
 ```
 
 Manual installation:
@@ -139,7 +150,7 @@ After setup, the Agent creates your novel project in the current directory:
 ├── .agent/               # Agent progress + task communication
 │   ├── status.md         # Progress marker (phase/volume/chapter)
 │   └── task/             # Order files for sub-agent dispatch
-└── .claude/              # Agent definitions + knowledge + memory
+├── .claude/              # Claude Code: agent definitions + knowledge + memory
     ├── agents/           # 7 agent definitions (deployed at init)
     ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
     └── memory/           # Dynamic writing memory (feedback per phase)
@@ -147,6 +158,11 @@ After setup, the Agent creates your novel project in the current directory:
         ├── chapter-memory.md
         ├── prompt-memory.md
         └── writing-memory.md
+└── .codex/               # Codex: 8 custom agents (TOML) + knowledge + memory
+    ├── agents/           # Custom agent definitions (deployed at init)
+    ├── skills/           # Standalone tools (memory-recording, roleplay-sandbox)
+    ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
+    └── memory/           # Dynamic writing memory (feedback per phase)
 ```
 
 All files are plain Markdown — you can open and edit them directly.
@@ -219,7 +235,7 @@ Agent asks if you want to choose one during setup.
 
 **Q: I'm not a programmer, can I install it?**
 
-Yes. Just copy and paste those commands into your terminal. The only requirement is having Claude Code installed.
+Yes. Just copy and paste those commands into your terminal. The only requirement is having Claude Code, OpenCode, Reasonix, or Codex installed.
 
 **Q: I upgraded the skill, how do I migrate my existing novel projects to the new format?**
 
@@ -236,6 +252,32 @@ Default config is "low AI flavor" — common machine phrases prohibited ("cannot
 **Q: Can I use my own writing style?**
 
 Yes. After project creation, there's a writing style file where you can write in your preferences, and all subsequent chapters will follow this style.
+
+## Codex Integration
+
+This skill also supports [Codex](https://developers.openai.com/codex) (OpenAI's coding agent). The skill itself is installed **user-level**, while agents/skills/knowledge/memory are deployed **project-level** into `.codex/` at init time.
+
+### Install
+
+```bash
+git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
+```
+
+Installs to `~/.codex/skills/awesome-novel/`.
+
+### Initialize a project
+
+```bash
+python tools/init.py <novel-project-path> --genre <number> --platform codex
+```
+
+The 8 custom agents are deployed as Codex TOML files (`.codex/agents/*.toml`, with `name` / `description` / `developer_instructions`), standalone tools as `.codex/skills/<name>/SKILL.md`, and anti-AI rules, style preferences, format specs, and writing memory land in `.codex/knowledge/` / `.codex/memory/`.
+
+### Start writing
+
+Open the project directory in Codex and call `@novel-agent` to enter the writing loop. In Codex, novel-agent dispatches sub-agents with `spawn_agent` (agent name = the TOML name under `.codex/agents/`); the order-file protocol is identical to the other platforms.
+
+Upgrade later with `python tools/sync-project.py <novel-project-path> --platform codex`.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix</em>
+  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix / Codex</em>
 </p>
 
 <p align="center">
@@ -8,6 +8,7 @@
   <a href="https://docs.anthropic.com/en/docs/claude-code/overview"><img src="https://img.shields.io/badge/Claude%20Code-%E2%9C%93%20%E6%94%AF%E6%8C%81-6B46C1?style=flat-square" alt="Claude Code"></a>
   <a href="#opencode"><img src="https://img.shields.io/badge/OpenCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-4A90D9?style=flat-square" alt="OpenCode"></a>
   <a href="#reasonix-集成"><img src="https://img.shields.io/badge/Reasonix-%E2%9C%93%20%E6%94%AF%E6%8C%81-16A34A?style=flat-square" alt="Reasonix"></a>
+  <a href="#codex-集成"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
   <br>
@@ -67,7 +68,7 @@
 
 ## 你需要什么
 
-- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode) 或 **Reasonix** 的电脑
+- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix** 或 **Codex** 的电脑
 - 大概 1 分钟完成安装
 
 
@@ -95,6 +96,16 @@ cd <小说项目路径> && reasonix code
 
 > 用 `--genre <编号>` 指定预置题材，不传则交互式选题材。装好后在项目目录里输入 `@novel-agent` 开始写作。
 
+**Codex：**
+
+Codex 的 skill 是**用户级安装**（`~/.codex/skills/awesome-novel/`），小说项目内的 agents/skills/knowledge/memory 则在初始化时**项目级部署**到 `.codex/`：
+
+```bash
+git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
+python tools/init.py <小说项目路径> --platform codex
+cd <小说项目路径>  # 然后在 Codex 中调用 @novel-agent 开始写作
+```
+
 或者手动复制（以 Claude Code 为例）：
 ```bash
 git clone https://github.com/modoojunko/awesome-novel-skill.git
@@ -111,6 +122,8 @@ echo "安装完成!"
 ```
 
 > **OpenCode 用户注意：** 安装路径为 `~/.config/opencode/skills/awesome-novel/`，初始化后 agent 定义部署在项目 `.opencode/agents/` 下，OpenCode 自动发现。详情见下方 [OpenCode 集成](#opencode) 说明。
+
+> **Codex 用户注意：** skill 安装到 `~/.codex/skills/awesome-novel/`，初始化后 8 个自定义 agent 以 TOML 形式部署在项目 `.codex/agents/` 下，Codex 自动发现。详情见下方 [Codex 集成](#codex-集成) 说明。
 
 看到 "安装完成" 就可以了。
 
@@ -171,11 +184,11 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 ├── .agent/               # Agent 进度 + 任务通信
 │   ├── status.md         # 进度标记（phase/volume/chapter）
 │   └── task/             # 子 agent 间 order 文件
-├── .opencode/            # OpenCode 用（三选一，由 init.py --platform 决定）
+├── .opencode/            # OpenCode 用（四选一，由 init.py --platform 决定）
 │   ├── agents/           # 8 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆
-├── .claude/              # Claude Code 用（三选一）
+├── .claude/              # Claude Code 用（四选一）
 │   ├── agents/           # 8 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆（各环节作者反馈）
@@ -183,13 +196,18 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 │       ├── chapter-memory.md
 │       ├── prompt-memory.md
 │       └── writing-memory.md
-└── .reasonix/            # Reasonix 用（三选一）
+├── .reasonix/            # Reasonix 用（四选一）
     ├── skills/           # 10 个 SKILL.md（agents 即 skills）
+    ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
+    └── memory/           # 写作动态记忆
+└── .codex/               # Codex 用（四选一）
+    ├── agents/           # 8 个自定义 agent（TOML，初始化时部署）
+    ├── skills/           # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
 ```
 
-这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` 不会同时存在。
+这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` 不会同时存在。
 
 ### 规划故事骨架
 
@@ -262,7 +280,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 
 **Q: 我不会编程，能装吗？**
 
-能。上面那几行命令复制粘贴到终端，回车就行。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode 或 Reasonix。
+能。上面那几行命令复制粘贴到终端，回车就行。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix 或 Codex。
 
 **Q: 我升级了技能，之前写的小说项目怎么迁移到新格式？**
 
@@ -474,3 +492,43 @@ Reasonix 项目把 agent 定义以 skill 形式部署在 `.reasonix/skills/`，�
 ```
 
 升级时用 `python tools/sync-project.py <小说项目路径> --platform reasonix` 同步最新框架。
+
+## Codex 集成
+
+本 skill 也支持 [Codex](https://developers.openai.com/codex)（OpenAI 的 AI 编码 agent）。skill 本体**用户级安装**，小说项目内的 agents/skills/knowledge/memory 全部**项目级部署**在 `.codex/`。
+
+### 安装
+
+```bash
+git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
+```
+
+安装到 `~/.codex/skills/awesome-novel/`。
+
+### 初始化项目
+
+```bash
+python tools/init.py <小说项目路径> --genre <编号> --platform codex
+```
+
+初始化后 8 个自定义 agent 以 Codex 官方 TOML 格式部署到项目 `.codex/agents/*.toml`（`name` / `description` / `developer_instructions`），独立交互工具（memory-recording、roleplay-sandbox）部署为 `.codex/skills/<name>/SKILL.md`，反 AI 规则、文风偏好、格式规范与写作记忆分别落在 `.codex/knowledge/`、`.codex/memory/`。
+
+### 开始写作
+
+在 Codex 中打开项目目录，调用 `@novel-agent` 进入写作循环。Codex 环境里 novel-agent 用 `spawn_agent` 调度子 agent（agent 名 = `.codex/agents/*.toml` 的 name），order 文件协议与其余平台一致。
+
+### 项目结构差异
+
+```
+.codex/
+├── agents/               # 8 个自定义 agent（TOML）
+│   ├── novel-agent.toml
+│   ├── writer.toml
+│   ├── volume-planner.toml
+│   └── ...
+├── skills/               # 独立交互工具（memory-recording、roleplay-sandbox）
+├── knowledge/            # 反 AI 规则、文风偏好、永久记忆、格式规范
+└── memory/               # 写作动态记忆
+```
+
+升级时用 `python tools/sync-project.py <小说项目路径> --platform codex` 同步最新框架。

--- a/SKILL.md
+++ b/SKILL.md
@@ -16,6 +16,15 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 
 **调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ Task 工具调用子 agent → 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。
 
+## Codex 集成说明
+
+本 skill 也支持 Codex。skill 本体**用户级安装**到 `~/.codex/skills/awesome-novel/`；`init.py --platform codex` 初始化小说项目时，把 8 个自定义 agent 部署为项目级 `.codex/agents/*.toml`（Codex 官方 TOML 格式，含 `name`/`description`/`developer_instructions`）：
+- `@novel-agent` — 总指挥 agent（TOML 名 `novel-agent`）
+- `@volume-planner`、`@chapter-planner` 等 — 子 agent（TOML 名与源 agent 一致）
+- **独立工具** — `memory-recording`、`roleplay-sandbox` 部署为 `.codex/skills/<name>/SKILL.md`
+
+**调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ 用 `spawn_agent` 调度子 agent（agent 名 = `.codex/agents/*.toml` 的 name）→ 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。order 文件协议与其余平台完全一致。
+
 ## 检测流程 — 严格按此执行，禁止跳过
 
 ```
@@ -41,7 +50,7 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 - 确认后必须运行 `init.py`，禁止手动创建目录结构替代
 - **禁止在 skill 安装目录（含 `skills/awesome-novel` 路径）内运行 `init.py`** — 此目录是技能仓库，不是小说项目
 - 如果当前目录是 skill 安装目录，应提示作者切换到目标目录后再执行
-- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`），方可进入 `@novel-agent`
+- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/`），方可进入 `@novel-agent`
 - 如果 `init.py` 报错，必须先修复问题重新执行，不允许绕过
 
 ## 初始化 — 先询问，确认后执行，不可跳过
@@ -56,8 +65,8 @@ python tools/init.py [project-path] [--genre <编号>]
 `init.py` 会：
 1. 选题材
 2. 创建项目骨架（settings/、volumes/、chapters/、prompts/、archives/）
-3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix 不部署 agents，agents 即 `.reasonix/skills/`）
-4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/`）
+3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix 不部署 agents，agents 即 `.reasonix/skills/`；Codex → `.codex/agents/*.toml`）
+4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/` / `.codex/knowledge/`）
 5. 按题材继承格式规范、题材案例到平台 knowledge 目录
 6. 创建空白的写作记忆文件（平台 memory 目录）
 7. 创建永久记忆占位文件（平台 knowledge 目录）
@@ -219,20 +228,25 @@ cp old/prompts/*.txt prompts/ 2>/dev/null
 ├── .agent/
 │   ├── status.md         # 进度追踪
 │   └── task/             # agent 间 order 文件
-├── .claude/             # Claude Code 用（平台一，三选一）
+├── .claude/             # Claude Code 用（平台一，四选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-├── .opencode/           # OpenCode 用（平台二，三选一）
+├── .opencode/           # OpenCode 用（平台二，四选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-└── .reasonix/           # Reasonix 用（平台三，三选一）
+├── .reasonix/           # Reasonix 用（平台三，四选一）
     ├── skills/          # 10 个 SKILL.md（agents 即 skills）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
+└── .codex/              # Codex 用（平台四，四选一）
+    ├── agents/          # 8 个自定义 agent（TOML）
+    ├── skills/          # 独立交互工具（memory-recording、roleplay-sandbox）
+    ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
+    └── memory/          # 写作动态记忆
 ```
-> 实际项目只生成三选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` 不会同时存在。
+> 实际项目只生成四选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` 不会同时存在。
 
 ## Agent 协作架构
 
@@ -248,7 +262,7 @@ novel-agent（总指挥）
   └─ 归档完成 → 卷完成判定 → 下一章 / 卷 N+1 / 完本
 ```
 
-各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
+各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/*.toml`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
 
 **可选工具：** 剧情推演沙盘（`skills/roleplay-sandbox.md`）是独立的交互式工具，不在 agent 调度链中。作者卡剧情时主动调用，产出推演记录（`sandbox/`）供编写章纲时参考。
 

--- a/docs/superpowers/specs/2026-08-03-platform-adaptation-design.md
+++ b/docs/superpowers/specs/2026-08-03-platform-adaptation-design.md
@@ -179,3 +179,18 @@ reasonix / opencode 纯原生结果：
 - 不新增平台（Gemini CLI / Codex / Cursor 等）——只抽象，以后加配置一行。
 - 不改 `install.sh`（reasonix 走项目级部署，与设计文档一致）。
 - 不做旧项目 `.claude/` → `.reasonix/` 的自动迁移。
+
+---
+
+## 十一、扩展：Codex 平台（2026-08-09）
+
+按 §十 的抽象设计新增第四平台（本条取代 §十 中"不新增平台"对 Codex 的约束）：
+
+- **目录约定**：`Platform("codex", "Codex", ".codex", agents="agents", skills="skills", knowledge="knowledge", memory="memory", detect_keywords=("codex",))`
+- **agents 形态**：Codex 自定义 agent 是官方 TOML（`name` / `description` / `developer_instructions`），`deploy_codex_agents()` 把 8 个 Claude frontmatter 定义转换为 `.codex/agents/*.toml`；frontmatter 声明的 SOP 内联进 `developer_instructions`，`.claude/knowledge|memory` 引用改写为 `.codex/` 对应目录
+- **工具映射**：`Agent` → `spawn_agent`（novel-agent 指令内附 Codex 调度适配段，agent 名 = TOML 名）
+- **skills**：只把独立交互工具（memory-recording、roleplay-sandbox）部署为 `.codex/skills/<name>/SKILL.md`
+- **依赖**：转换依赖 pyyaml，`ensure_yaml()` 在 init/sync 入口预检，缺失时明确报错退出（防"退出 0 但产物损坏"）
+- **安装**：`install.sh codex` / `install.ps1 codex` 装到用户级 `~/.codex/skills/awesome-novel/`；小说项目内 agents/skills/knowledge/memory 全部项目级部署到 `.codex/`
+- **模板**：codex 项目生成 `AGENTS.md`（内容取自 `templates/AGENTS.codex.md`），不生成 `CLAUDE.md`；`AGENTS.codex.md` 模板源不复制进项目
+- **同步**：`.codex/agents|skills` 视为派生产物，靠源指纹检测，`sync-project.py --platform codex` 重新生成

--- a/install.ps1
+++ b/install.ps1
@@ -16,7 +16,7 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code", "opencode")]
+    [ValidateSet("claude-code", "opencode", "codex")]
     [string]$Platform
 )
 
@@ -28,6 +28,9 @@ switch ($Platform) {
     }
     "opencode" {
         $DEST_DIR = "$HOME_DIR\.config\opencode\skills\awesome-novel"
+    }
+    "codex" {
+        $DEST_DIR = "$HOME_DIR\.codex\skills\awesome-novel"
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -e
 
 usage() {
     echo "用法: $0 <平台>"
-    echo "平台: claude-code, hermes, openclaw, deepseek-tui"
+    echo "平台: claude-code, opencode, codex, hermes, openclaw, deepseek-tui"
     exit 1
 }
 
@@ -47,6 +47,9 @@ case "$PLATFORM" in
     opencode)
         SKILLS_DIR="$HOME/.config/opencode/skills"
         ;;
+    codex)
+        SKILLS_DIR="$HOME/.codex/skills"
+        ;;
     *)
         echo "不支持的平台: $PLATFORM"
         usage
@@ -62,8 +65,10 @@ export NOVEL_SKILL_HOME="$DEST"
 # 注意：NOVEL_SKILL_HOME 只在本脚本会话内生效，不再写入 ~/.profile / ~/.bashrc 等。
 # 持久化会遮蔽仓库来源（init.py 以 __file__ 解析技能根，env 优先会导致新项目部署安装版旧提示词）。
 
-# 安全检查：DEST 必须是以 $HOME 开头的 skills/awesome-novel 路径
-CANONICAL_DEST="$(cd "$(dirname "$DEST")" 2>/dev/null && pwd)/$(basename "$DEST")"
+# 安全检查：DEST 必须是以 $HOME 开头的 skills/awesome-novel 路径。
+# 先创建父目录，避免全新 HOME（skills 目录尚不存在）时 dirname 取不到导致误拒。
+mkdir -p "$(dirname "$DEST")"
+CANONICAL_DEST="$(cd "$(dirname "$DEST")" && pwd)/$(basename "$DEST")"
 if [[ -z "$DEST" || "$DEST" == "/" || "$CANONICAL_DEST" != "$HOME/."*"/skills/awesome-novel" ]]; then
     echo "错误：安装目标路径异常 ($DEST)，中止。"
     exit 1

--- a/knowledge/format-specs/memory-format-spec.md
+++ b/knowledge/format-specs/memory-format-spec.md
@@ -7,7 +7,7 @@
 ## 一、文件结构
 
 ```
-.claude/
+<平台目录>/
 ├── memory/                          # 动态记忆（各环节实时记录）
 │   ├── volume-memory.md             # 卷纲环节记忆
 │   ├── chapter-memory.md            # 章纲环节记忆
@@ -17,6 +17,8 @@
 └── knowledge/
     └── permanent-memory.md          # 永久记忆（从 memory/ 晋升的高频条目）
 ```
+
+> 平台目录由 init.py 按 `--platform` 决定：Claude Code → `.claude/`、OpenCode → `.opencode/`、Reasonix → `.reasonix/`、Codex → `.codex/`。
 
 ## 二、文件头
 

--- a/skill.json
+++ b/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "awesome-novel",
   "version": "1.0.0",
-  "description": "和 AI 协作写小说的工作流系统。从世界观搭建到角色塑造，从章节规划到正文写作，支持 DeepSeek TUI、Claude Code、Hermes 和 OpenClaw。",
+  "description": "和 AI 协作写小说的工作流系统。从世界观搭建到角色塑造，从章节规划到正文写作，支持 Codex、Claude Code、OpenCode 和 Reasonix。",
   "author": {
     "name": "modoojunko",
     "url": "https://github.com/modoojunko"

--- a/templates/AGENTS.codex.md
+++ b/templates/AGENTS.codex.md
@@ -1,0 +1,22 @@
+# {project-name}
+
+## Codex 指引
+
+本项目的小说写作流程由 8 个 agent 协作完成，定义在 `.codex/agents/` 下（TOML 自定义 agent）。
+
+**开始写作：** 在 Codex 中通过 `@novel-agent` 或 `spawn_agent` 调用 novel-agent 进入写作循环。
+
+**写作流程：** 设定 → 卷纲 → 章纲 → 提示词 → 正文 → 去AI味 → 验收 → 归档 → 下一章
+
+**项目结构：**
+- `story.md` — 项目索引 + 主线拆纲
+- `settings/` — 世界观、角色、写作风格、时间线
+- `volumes/` — 卷纲
+- `chapters/` — 章纲
+- `prompts/` — 提示词
+- `archives/` — 正文
+- `.agent/` — 状态追踪 + agent 通信（order 文件）
+- `.codex/agents/` — 8 个自定义 agent 定义（novel-agent, volume-planner, chapter-planner 等）
+- `.codex/skills/` — 独立交互工具（memory-recording、roleplay-sandbox）
+- `.codex/memory/` — 写作动态记忆（各环节作者反馈，持续积累）
+- `.codex/knowledge/` — 反 AI 规则、文风偏好、永久记忆、题材参考材料

--- a/tools/init.py
+++ b/tools/init.py
@@ -2,7 +2,7 @@
 """
 awesome-novel-skill 项目初始化工具
 
-用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix>]
+用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix|codex>]
 
 平台缺省：--platform > NOVEL_PLATFORM > SKILL_HOME 路径识别 > claude。
 
@@ -22,7 +22,10 @@ from platforms import (
     Platform,
     convert_to_opencode,
     detect_platform,
+    deploy_codex_agents,
+    deploy_codex_skills,
     deploy_reasonix_skills,
+    ensure_yaml,
     rewrite_refs,
     resolve_skill_home,
 )
@@ -70,7 +73,7 @@ def main():
         a = args[i]
         if a == "--platform":
             if i + 1 >= len(args) or args[i + 1].startswith("--"):
-                print("错误: --platform 需要一个平台名（claude|opencode|reasonix）")
+                print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex）")
                 sys.exit(1)
             platform_override = args[i + 1]
             i += 2
@@ -93,6 +96,7 @@ def main():
     except ValueError as e:
         print(e)
         sys.exit(1)
+    ensure_yaml(platform)
     print(f"平台: {platform.label}")
 
     # 解析可选参数
@@ -121,12 +125,17 @@ def main():
     # Step 2: 创建骨架
     create_skeleton(project_path, platform)
 
-    # Step 3: 部署 agent 定义
-    deploy_agents(project_path, platform)
+    # Step 3: 部署 agent 定义（codex 为 TOML 转换产物，reasonix agents 即 skills）
+    if platform.key == "codex":
+        deploy_codex_agents(project_path, SKILL_HOME, platform)
+    else:
+        deploy_agents(project_path, platform)
 
-    # Step 3.5: 部署 Reasonix skills（仅 reasonix 平台）
+    # Step 3.5: 部署平台 skills（reasonix 生成 10 个 SKILL.md；codex 只部署独立工具）
     if platform.key == "reasonix":
         deploy_reasonix_skills(project_path, SKILL_HOME, platform)
+    elif platform.key == "codex":
+        deploy_codex_skills(project_path, SKILL_HOME, platform)
 
     # Step 4: 按题材继承记忆
     deploy_memory(project_path, genre)
@@ -152,6 +161,8 @@ def main():
         print("输入 @novel-agent 开始写作（Claude Code）")
     elif platform.key == "opencode":
         print("在 OpenCode 中通过 @novel-agent 开始写作")
+    elif platform.key == "codex":
+        print("在 Codex 中打开项目目录，调用 @novel-agent 开始写作")
     else:
         print("在 Reasonix 中运行 `reasonix code`，然后调用 @novel-agent 开始写作")
 
@@ -180,6 +191,9 @@ def _rewrite_template_refs(text: str, platform: Platform) -> str:
     if platform.key == "reasonix":
         text = text.replace(".claude/agents/", ".reasonix/skills/")
         text = text.replace(".opencode/agents/", ".reasonix/skills/")
+    elif platform.key == "codex":
+        text = text.replace(".claude/agents/", ".codex/agents/")
+        text = text.replace(".opencode/agents/", ".codex/agents/")
     else:  # opencode
         text = text.replace(".claude/agents/", f"{platform.root}/agents/")
     return rewrite_refs(text, platform)
@@ -210,6 +224,20 @@ def create_skeleton(project_path: Path, platform: Platform):
                     continue
                 target = project_path / rel_path
                 target.parent.mkdir(parents=True, exist_ok=True)
+                if platform.key == "codex" and item.name == "CLAUDE.md":
+                    # Codex 项目不生成 CLAUDE.md（Codex 只读 AGENTS.md）
+                    continue
+                if item.name == "AGENTS.codex.md":
+                    # 模板源仅用于生成 codex 项目的 AGENTS.md，不复制进项目
+                    continue
+                if platform.key == "codex" and item.name == "AGENTS.md":
+                    codex_tpl = SOURCE_TEMPLATES / "AGENTS.codex.md"
+                    if codex_tpl.exists():
+                        content = codex_tpl.read_text(encoding="utf-8")
+                        content = _rewrite_template_refs(content, platform)
+                        with open(target, "w", encoding="utf-8", newline="") as f:
+                            f.write(content)
+                        continue
                 if item.name in ("CLAUDE.md", "AGENTS.md") and platform.key != "claude":
                     with open(item, encoding="utf-8", newline="") as f:
                         content = f.read()

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -6,6 +6,7 @@ init.py / sync-project.py 共用本模块完成平台检测、目录派发、引
   - claude   → .claude/   agents=agents, knowledge, memory
   - opencode → .opencode/ agents=agents, knowledge, memory
   - reasonix → .reasonix/ agents=None（agents 即 skills）, skills=skills, knowledge, memory
+  - codex    → .codex/    agents=agents（TOML 转换产物）, skills=skills, knowledge, memory
 
 模块名用 platforms（复数）是刻意避开标准库 platform（单数）同名冲突。
 """
@@ -13,6 +14,7 @@ init.py / sync-project.py 共用本模块完成平台检测、目录派发、引
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -52,6 +54,8 @@ PLATFORMS = {
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=("opencode",)),
     "reasonix": Platform("reasonix", "Reasonix", ".reasonix", agents=None,
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=("reasonix",)),
+    "codex":    Platform("codex", "Codex", ".codex", agents="agents",
+                         skills="skills", knowledge="knowledge", memory="memory", detect_keywords=("codex",)),
 }
 
 
@@ -73,12 +77,33 @@ def detect_platform(skill_home: Path, override: str | None = None) -> Platform:
 
 
 def rewrite_refs(text: str, platform: Platform) -> str:
-    """部署内容里的 Claude Code 路径引用 → 平台路径。仅改 knowledge/memory，claude 原样返回。"""
+    """部署内容里的 Claude Code 路径引用 → 平台路径。claude 原样返回。
+
+    knowledge/memory 精确替换后，剩余裸 .claude/（禁写区、目录树说明等）
+    整体替换为平台根，避免部署产物残留失效引用。
+    """
     if platform.key == "claude":
         return text
     text = text.replace(".claude/knowledge/", f"{platform.root}/knowledge/")
     text = text.replace(".claude/memory/", f"{platform.root}/memory/")
+    text = text.replace(".claude/", f"{platform.root}/")
     return text
+
+
+def ensure_yaml(platform: Platform) -> None:
+    """非 claude 平台的 agent 转换依赖 pyyaml；缺失时明确报错退出。
+
+    claude 平台是纯复制不转换，不需要 pyyaml。init.py / sync-project.py
+    在平台检测后调用本函数，避免"退出 0 却产出损坏产物"的静默故障。
+    """
+    if platform.key == "claude":
+        return
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        print(f"错误: {platform.label} 平台需要 pyyaml（pip install pyyaml），当前环境未安装。",
+              file=sys.stderr)
+        sys.exit(1)
 
 
 def resolve_skill_home() -> Path:
@@ -314,3 +339,183 @@ def convert_to_opencode(text: str) -> str:
     )
     new_fm = "\n".join(new_lines).rstrip() + "\n" + perm_text
     return "---" + new_fm + "---" + parts[2]
+
+
+# ---------------------------------------------------------------
+# Codex agent 转换（Claude Code agent frontmatter → Codex 自定义 agent TOML）
+# ---------------------------------------------------------------
+
+_CODEX_TOOL_MAP = {
+    "Read": "Read",
+    "Write": "Write",
+    "Edit": "Edit",
+    "Glob": "Glob",
+    "Grep": "Grep",
+    "Agent": "spawn_agent",   # Claude Code Agent 工具 ↔ Codex spawn_agent
+}
+
+
+def _toml_escape(s: str) -> str:
+    """单行 TOML 基本字符串转义。"""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _toml_multiline(s: str) -> str:
+    """多行 TOML 基本字符串转义（反斜杠 + 结束定界符冲突）。"""
+    return s.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+
+def _agent_skill_paths(data: dict) -> list:
+    """从 agent frontmatter 的 skills 列表提取 skills/*.md 相对路径。"""
+    paths = []
+    skills = data.get("skills") or []
+    if not isinstance(skills, list):
+        return paths
+    for s in skills:
+        if isinstance(s, dict):
+            path = s.get("path")
+        elif isinstance(s, str):
+            path = s
+        else:
+            continue
+        if isinstance(path, str) and path.startswith("skills/"):
+            paths.append(Path(path))
+    return paths
+
+
+def convert_to_codex(text: str, skill_home: Path) -> str:
+    """Claude Code agent frontmatter → Codex 自定义 agent TOML。
+
+    - 必填字段：name / description / developer_instructions（Codex 官方约定）
+    - tools：Codex agent TOML 无工具白名单字段，改为在指令中声明允许工具；
+      Agent → spawn_agent（调度说明见 novel-agent 适配段）
+    - skills：frontmatter 声明的 SOP 内联进 developer_instructions（与 reasonix 一致）
+    - 路径改写：.claude/knowledge、.claude/memory → .codex/ 对应目录
+    """
+    parts = text.split("---", 2)
+    if len(parts) != 3:
+        return text
+    try:
+        import yaml
+        data = yaml.safe_load(parts[1])
+    except Exception:
+        return text
+    if not isinstance(data, dict):
+        return text
+
+    name = str(data.get("name", "unknown")).strip()
+    desc = str(data.get("description", "") or "").strip()
+
+    tools_raw = str(data.get("tools", "") or "")
+    allowed = []
+    for t in tools_raw.split(","):
+        t = t.strip()
+        if not t:
+            continue
+        mapped = _CODEX_TOOL_MAP.get(t, t)
+        if mapped not in allowed:
+            allowed.append(mapped)
+
+    body = parts[2].strip()
+    if name == "novel-agent":
+        body += (
+            "\n\n## Codex 调度适配（本环境无 Agent 工具）\n"
+            "在 Codex 环境调度子 agent 用 `spawn_agent` 工具：\n"
+            "- 子 agent 名即 `.codex/agents/` 下的 TOML 名（writer / volume-planner / "
+            "chapter-planner / prompt-crafter / anti-ai / reader / updater）\n"
+            "- 把 order 文件内容作为任务消息传给子 agent；order 文件协议（status: DONE）不变\n"
+            "- 一次只调度一个任务，等 DONE 后再调度下一个；禁止把 novel-agent 本身作为子 agent 调度\n"
+        )
+
+    tool_line = ""
+    if allowed:
+        tool_line = f"\n\n（自动生成）本 agent 允许使用的工具：{'、'.join(allowed)}"
+    body += tool_line
+
+    sop_sections = []
+    for rel in _agent_skill_paths(data):
+        sop = skill_home / rel
+        if sop.exists():
+            sop_sections.append(
+                f"\n---\n\n## 执行 SOP：{sop.name}\n\n{sop.read_text(encoding='utf-8').strip()}"
+            )
+    instructions = body + "\n".join(sop_sections)
+    instructions = rewrite_refs(instructions, PLATFORMS["codex"])
+
+    lines = [
+        f"# 由 awesome-novel 自动生成，源文件: agents/{name}.md",
+        f'name = "{name}"',
+        f'description = "{_toml_escape(desc)}"',
+        "",
+        'developer_instructions = """',
+        _toml_multiline(instructions).rstrip(),
+        '"""',
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def deploy_codex_agents(project: Path, skill_home: Path, platform: Platform) -> None:
+    """生成 <project>/<platform.root>/agents/<name>.toml（8 个），引用改写为平台路径。
+
+    仅 codex 平台调用。Claude agent frontmatter → Codex TOML，与 sync 保持一致。
+    """
+    if platform.key != "codex":
+        return
+    agents_dir = skill_home / "agents"
+    target = platform.agents_dir(project)
+    if target is None:
+        return
+    target.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for item in sorted(agents_dir.rglob("*.md")):
+        if item.name == ".gitkeep":
+            continue
+        dest = target / (item.stem + ".toml")
+        dest.write_text(
+            convert_to_codex(item.read_text(encoding="utf-8"), skill_home),
+            encoding="utf-8",
+        )
+        count += 1
+    print(f"  ✅ 已部署 {count} 个 Codex agent 定义到 {target}")
+
+
+def _convert_codex_inline_skill(text: str, name: str) -> str:
+    """纯正文 SOP → Codex skill（SKILL.md，name/description frontmatter）。"""
+    desc = ""
+    for ln in text.split("\n"):
+        if ln.strip().startswith("# ") and not ln.strip().startswith("## "):
+            desc = ln.strip().lstrip("# ").strip()
+            break
+    desc_clean = desc.replace('"', "'")
+    fm = (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: \"{desc_clean or name}（由 awesome-novel 自动生成的 Codex skill）\"\n"
+        f"---\n"
+    )
+    return fm + "\n" + text.strip()
+
+
+def deploy_codex_skills(project: Path, skill_home: Path, platform: Platform) -> None:
+    """生成独立交互工具为 Codex skill（<project>/<platform.root>/skills/<name>/SKILL.md）。
+
+    仅 codex 平台调用。8 个 agent 走 .codex/agents/*.toml（deploy_codex_agents），
+    此处只部署不进调度链的独立工具（memory-recording、roleplay-sandbox）。
+    """
+    if platform.key != "codex":
+        return
+    skills_dir = skill_home / "skills"
+    target = platform.skills_dir(project)
+    if target is None:
+        return
+    target.mkdir(parents=True, exist_ok=True)
+    for skill_name in ("memory-recording", "roleplay-sandbox"):
+        sf = skills_dir / f"{skill_name}.md"
+        if sf.exists():
+            body = _convert_codex_inline_skill(sf.read_text(encoding="utf-8"), skill_name)
+            body = rewrite_refs(body, platform)
+            skill_dir = target / skill_name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    print(f"  ✅ 已部署 Codex 独立工具 skill 到 {target}")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
-# init.py 使用 Python 标准库，无需额外依赖
+# Python 主体使用标准库；opencode / reasonix / codex 平台的 agent 转换需要 pyyaml（CI 自动安装）
+pyyaml

--- a/tools/sync-project.py
+++ b/tools/sync-project.py
@@ -29,9 +29,12 @@ from pathlib import Path
 
 from platforms import (
     Platform,
+    convert_to_codex,
     convert_to_opencode,
     detect_platform,
+    deploy_codex_skills,
     deploy_reasonix_skills,
+    ensure_yaml,
     resolve_skill_home,
     rewrite_refs,
 )
@@ -65,7 +68,7 @@ def main():
         if idx + 1 < len(sys.argv) and not sys.argv[idx + 1].startswith("--"):
             platform_override = sys.argv[idx + 1]
         else:
-            print("错误: --platform 需要一个平台名（claude|opencode|reasonix）")
+            print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex）")
             sys.exit(1)
     platform_override = platform_override or os.environ.get("NOVEL_PLATFORM")
     try:
@@ -73,6 +76,7 @@ def main():
     except ValueError as e:
         print(e)
         sys.exit(1)
+    ensure_yaml(platform)
 
     # 处理 Windows 中文路径乱码：从 os.environ 重新取当前目录
     raw_arg = sys.argv[1]
@@ -194,8 +198,8 @@ def check_freshness(project: Path, platform: Platform):
         sys.exit(0)
     else:
         changes = find_changes(project, platform)
-        if not changes and platform.key == "reasonix":
-            print("有更新可用（源文件变化，reasonix skill 由同步时重新生成）。")
+        if not changes and platform.key in ("reasonix", "codex"):
+            print("有更新可用（源文件变化，平台派生产物由同步时重新生成）。")
         else:
             lines = [f"有更新可用 ({len(changes)} 个文件发生变化):"]
             for f in changes:
@@ -226,6 +230,8 @@ def find_changes(project: Path, platform: Platform) -> list[str]:
             continue
         if platform.key == "reasonix" and name == "skills":
             continue  # 派生产物靠源指纹检测，同步时重新生成
+        if platform.key == "codex" and name in ("agents", "skills"):
+            continue  # TOML/SKILL.md 是派生产物，靠源指纹检测，同步时重新生成
         for item in sorted(src_dir.rglob("*.md")):
             if item.name == ".gitkeep":
                 continue
@@ -304,6 +310,19 @@ def sync_agents(project_path: Path, platform: Platform) -> int:
             dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_text(content, encoding="utf-8")
             count += 1
+    elif platform.key == "codex":
+        # codex agents 是转换产物（.codex/agents/*.toml），与 init 保持一致
+        count = 0
+        for item in sorted(AGENT_DIR.rglob("*.md")):
+            if item.name == ".gitkeep":
+                continue
+            content = convert_to_codex(item.read_text(encoding="utf-8"), SKILL_HOME)
+            dest = target / (item.stem + ".toml")
+            if dest.exists() and dest.read_text(encoding="utf-8") == content:
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+            count += 1
     else:
         count = _sync_dir(AGENT_DIR, target, "*.md")
     if count > 0:
@@ -318,6 +337,11 @@ def sync_skills(project_path: Path, platform: Platform) -> int:
         deploy_reasonix_skills(project_path, SKILL_HOME, platform)
         n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
         print(f"  [OK] reasonix skills: {n} 个 SKILL.md 已重新生成")
+        return n
+    if platform.key == "codex":
+        deploy_codex_skills(project_path, SKILL_HOME, platform)
+        n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
+        print(f"  [OK] codex skills: {n} 个 SKILL.md 已重新生成")
         return n
     target = platform.skills_dir(project_path)
     target.mkdir(parents=True, exist_ok=True)

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -5,15 +5,22 @@
 返回码 0 = 全部通过，非 0 = 有失败（CI 用）。
 
 覆盖：
-- 单元：platforms 模块（配置/检测/引用改写）
-- E2E：init.py 三平台布局 + 引用改写 + reasonix 10 个 skill
-- E2E：sync-project.py 三平台同步 + --check
+- 单元：platforms 模块（配置/检测/引用改写/yaml 预检）
+- E2E：init.py 各平台布局 + 引用改写 + reasonix 10 个 skill + codex TOML agent（含 tomllib 解析）
+- E2E：sync-project.py 各平台同步 + --check
+- E2E：install.sh 全新 HOME 首次安装（F1 回归）+ 缺 pyyaml 负向场景（F5 回归）
 """
 
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:  # Python < 3.11
+    tomllib = None
 
 TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(TOOLS))
@@ -32,8 +39,8 @@ def check(name: str, cond: bool, detail: str = ""):
         print(f"  FAIL {name}  {detail}")
 
 
-def run(cmd, cwd=None) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, encoding="utf-8")
+def run(cmd, cwd=None, env=None) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, encoding="utf-8", env=env)
 
 
 def init_project(tmp: Path, platform_key: str, genre: str = "1"):
@@ -66,6 +73,10 @@ def test_rewrite():
           out == "先 Read `.reasonix/knowledge/anti-ai.md` 和 `.reasonix/memory/volume-memory.md`",
           out)
     check("claude 原样", p.rewrite_refs(text, p.PLATFORMS["claude"]) == text)
+    out = p.rewrite_refs(text, p.PLATFORMS["codex"])
+    check("codex 改写两处",
+          out == "先 Read `.codex/knowledge/anti-ai.md` 和 `.codex/memory/volume-memory.md`",
+          out)
 
 
 def test_config():
@@ -76,8 +87,37 @@ def test_config():
     check("reasonix agents=None", p.PLATFORMS["reasonix"].agents_dir(Path("P")) is None)
     check("reasonix skills 路径",
           p.PLATFORMS["reasonix"].skills_dir(Path("P")) == Path("P") / ".reasonix" / "skills")
+    check("codex agents 路径",
+          p.PLATFORMS["codex"].agents_dir(Path("P")) == Path("P") / ".codex" / "agents")
+    check("codex skills 路径",
+          p.PLATFORMS["codex"].skills_dir(Path("P")) == Path("P") / ".codex" / "skills")
     check("unknown key 抛错", _raises(p.platform_from_key, "bad-key"))
     check("检测优先显式覆盖", p.detect_platform(Path("d:/x/.reasonix/skills"), "claude").key == "claude")
+    check("检测 codex 路径",
+          p.detect_platform(Path("d:/x/.codex/skills/awesome-novel")).key == "codex")
+
+
+def test_yaml_precheck():
+    print("[unit] ensure_yaml")
+    import platforms as p
+    p.ensure_yaml(p.PLATFORMS["claude"])  # claude 纯复制，不依赖 pyyaml
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("模拟缺 pyyaml")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = fake_import
+    try:
+        check("缺 yaml 时 codex 报错", _raises_system_exit(p.ensure_yaml, p.PLATFORMS["codex"]))
+        check("缺 yaml 时 opencode 报错",
+              _raises_system_exit(p.ensure_yaml, p.PLATFORMS["opencode"]))
+        check("缺 yaml 时 reasonix 报错",
+              _raises_system_exit(p.ensure_yaml, p.PLATFORMS["reasonix"]))
+    finally:
+        builtins.__import__ = real_import
 
 
 def _raises(fn, *a) -> bool:
@@ -88,14 +128,23 @@ def _raises(fn, *a) -> bool:
         return True
 
 
+def _raises_system_exit(fn, *a) -> bool:
+    try:
+        fn(*a)
+        return False
+    except SystemExit:
+        return True
+
+
 # ---------------- E2E init ----------------
 
 def test_init_layout():
-    print("[e2e] init.py 三平台布局")
+    print("[e2e] init.py 各平台布局")
     expect_map = {
         "claude":   (["agents", "knowledge", "memory"], [".reasonix"]),
         "opencode": (["agents", "knowledge", "memory"], [".claude", ".reasonix"]),
         "reasonix": (["skills", "knowledge", "memory"], [".claude"]),
+        "codex":    (["agents", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
     }
     for key, (subs, absents) in expect_map.items():
         with tempfile.TemporaryDirectory() as td:
@@ -119,6 +168,8 @@ def test_init_layout():
         w = (tmp / ".reasonix/skills/writer/SKILL.md").read_text(encoding="utf-8")
         check("reasonix writer 引用改写",
               ".reasonix/knowledge/" in w and ".claude/knowledge/" not in w)
+        nv = (tmp / ".reasonix/skills/novel-agent/SKILL.md").read_text(encoding="utf-8")
+        check("reasonix novel-agent 无 .claude 残留", ".claude" not in nv)
 
     # reasonix AGENTS.md 模板改写
     with tempfile.TemporaryDirectory() as td:
@@ -146,11 +197,50 @@ def test_init_layout():
         check("opencode writer 引用改写",
               ".opencode/knowledge/" in w and ".claude/knowledge/" not in w)
 
+    # codex TOML agent + skill + 模板
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "codex")
+        n = len(list((tmp / ".codex/agents").glob("*.toml")))
+        check("codex agents 数量=8", n == 8, f"实际 {n}")
+        w = (tmp / ".codex/agents/writer.toml").read_text(encoding="utf-8")
+        check("codex writer TOML 字段",
+              'name = "writer"' in w and "description" in w
+              and "developer_instructions" in w, w[:200])
+        check("codex writer 引用改写",
+              ".codex/knowledge/" in w and ".claude/knowledge/" not in w)
+        all_toml = "".join(
+            f.read_text(encoding="utf-8") for f in sorted((tmp / ".codex/agents").glob("*.toml"))
+        )
+        check("codex 全部 TOML 无 .claude 残留", ".claude" not in all_toml)
+        nv = (tmp / ".codex/agents/novel-agent.toml").read_text(encoding="utf-8")
+        check("codex novel-agent 调度适配",
+              "spawn_agent" in nv and ".codex/agents/" in nv)
+        check("codex skill roleplay-sandbox",
+              (tmp / ".codex/skills/roleplay-sandbox/SKILL.md").exists())
+        check("codex skill memory-recording",
+              (tmp / ".codex/skills/memory-recording/SKILL.md").exists())
+        ag = (tmp / "AGENTS.md").read_text(encoding="utf-8")
+        check("codex AGENTS.md 指向 .codex/agents", ".codex/agents/" in ag, ag[:200])
+        check("codex 无 CLAUDE.md", not (tmp / "CLAUDE.md").exists())
+        check("codex 无 AGENTS.codex.md 模板副本",
+              not (tmp / "AGENTS.codex.md").exists())
+        if tomllib is not None:
+            parse_ok = True
+            for f in sorted((tmp / ".codex/agents").glob("*.toml")):
+                try:
+                    tomllib.loads(f.read_text(encoding="utf-8"))
+                except Exception as e:
+                    parse_ok = False
+                    detail = f"{f.name}: {e}"
+                    break
+            check("codex TOML tomllib 可解析", parse_ok, detail if not parse_ok else "")
+
 
 # ---------------- E2E sync ----------------
 
 def test_sync():
-    print("[e2e] sync-project.py 三平台同步")
+    print("[e2e] sync-project.py 各平台同步")
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         init_project(tmp, "claude")
@@ -178,6 +268,18 @@ def test_sync():
         check("reasonix sync 保持 skill", (tmp / ".reasonix/skills/writer/SKILL.md").exists())
         check("reasonix sync 无 .claude", not (tmp / ".claude").exists())
 
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "codex")
+        r = run([sys.executable, str(TOOLS / "sync-project.py"), str(tmp),
+                 "--platform", "codex"], cwd=str(tmp))
+        check("codex sync exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
+        w = (tmp / ".codex/agents/writer.toml").read_text(encoding="utf-8")
+        check("codex sync 保持 TOML 格式",
+              'name = "writer"' in w and "developer_instructions" in w
+              and ".codex/knowledge/" in w and ".claude/" not in w)
+        check("codex sync 无 .claude", not (tmp / ".claude").exists())
+
     # --check：无指纹首次 → exit 1
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
@@ -187,13 +289,50 @@ def test_sync():
         check("reasonix --check 无指纹 exit 1", r.returncode == 1, str(r.returncode))
 
 
+# ---------------- E2E install.sh / 负向场景 ----------------
+
+def test_install_fresh_home():
+    """F1 回归：全新 HOME（skills 目录尚不存在）首次安装不被安全校验误拒。"""
+    print("[e2e] install.sh codex 全新 HOME 首次安装")
+    with tempfile.TemporaryDirectory() as td:
+        home = Path(td) / "home"
+        home.mkdir()
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
+                cwd=str(TOOLS.parent), env=env)
+        check("fresh home install exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
+        dest = home / ".codex" / "skills" / "awesome-novel"
+        check("fresh home SKILL.md 存在", (dest / "SKILL.md").exists())
+        check("fresh home agents 存在", (dest / "agents").is_dir())
+
+
+def test_noyaml_e2e():
+    """F5 回归：缺 pyyaml 时 init --platform codex 明确报错退出，不产出损坏 TOML。"""
+    print("[e2e] 缺 pyyaml 时 init --platform codex 明确报错")
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        (tmp / "yaml.py").write_text('raise ImportError("blocked")\n', encoding="utf-8")
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(tmp) + os.pathsep + env.get("PYTHONPATH", "")
+        r = run([sys.executable, str(TOOLS / "init.py"), str(tmp / "proj"),
+                 "--genre", "1", "--platform", "codex"], cwd=str(tmp), env=env)
+        check("缺 yaml exit 1", r.returncode == 1, str(r.returncode))
+        check("缺 yaml 报错信息", "需要 pyyaml" in (r.stdout + r.stderr))
+        check("缺 yaml 无损坏 TOML 产物",
+              not (tmp / "proj" / ".codex" / "agents" / "writer.toml").exists())
+
+
 def main():
     for name, fn in [
         ("test_detect", test_detect),
         ("test_rewrite", test_rewrite),
         ("test_config", test_config),
+        ("test_yaml_precheck", test_yaml_precheck),
         ("test_init_layout", test_init_layout),
         ("test_sync", test_sync),
+        ("test_install_fresh_home", test_install_fresh_home),
+        ("test_noyaml_e2e", test_noyaml_e2e),
     ]:
         try:
             fn()


### PR DESCRIPTION
## 概述

新增 [Codex](https://developers.openai.com/codex) 平台支持，Closes #59。Codex 的 skill 按官方约定**用户级安装**（`~/.codex/skills/awesome-novel/`），小说项目内 agents/skills/knowledge/memory 由 `init.py --platform codex` **项目级部署**到 `.codex/`。

## 改动内容

- **平台适配层**（`tools/platforms.py`）：新增 `codex` 平台条目；`convert_to_codex()` 把 8 个 Claude agent frontmatter 转换为 Codex 官方 TOML（`name`/`description`/`developer_instructions`），frontmatter 声明的 SOP 内联进指令，`Agent` 工具映射为 `spawn_agent`，`.claude/knowledge|memory` 引用改写为 `.codex/` 对应目录
- **初始化**（`tools/init.py`）：`--platform codex` 部署 8 个 TOML agent 到 `.codex/agents/`、独立工具到 `.codex/skills/<name>/SKILL.md`；生成 Codex 版 `AGENTS.md`（模板 `templates/AGENTS.codex.md`），不生成 `CLAUDE.md`
- **同步**（`tools/sync-project.py`）：codex 的 agents/skills 视为派生产物，靠源指纹检测、同步时重新生成
- **安装**：`install.sh codex` / `install.ps1 codex` 装到用户级目录；修复全新 HOME 首次安装被安全校验误拒的问题（F1）
- **引用改写修复**（F2）：`rewrite_refs` 把剩余裸 `.claude/` 一并改写为平台根目录，novel-agent 等 TOML 无失效引用残留
- **依赖预检**（F5）：`ensure_yaml()` 在 init/sync 入口拦截缺 pyyaml 环境，明确报错退出，不再静默产出损坏 TOML
- **文档**：README（中/英）、SKILL.md、ARCHITECTURE.md、skill.json、根 AGENTS.md、平台适配设计 spec 同步；`memory-format-spec.md` 改平台无关表述（F3）
- **CI**（F4）：static.yml 增加平台测试步骤；`tools/requirements.txt` 声明 pyyaml

## 测试验证

- `tools/test_platforms.py`：**87/87 通过**（含 codex 单元/E2E/负向用例 + F1/F5 回归）
- `py_compile`、`check-agents.py`、`check-conflicts.py` 全部通过
- 新增用例"codex 项目不含 AGENTS.codex.md 模板副本"按先红后绿流程落地

## Demo 实测（Codex 环境）

在 Codex 内以 `init.py --platform codex` 初始化《问道青冥》demo 项目，按 `.codex/agents/*.toml` 流程跑完设定 → 卷纲 → 章纲 → 提示词 → 正文 → 去 AI 味 → 评审 → 归档，**第一章《藏经阁夜值》完成归档**（约 1800 字，8 个 order 全部 DONE，反 AI 扫描通过）。

## 检视说明

按仓库规范自查一遍：四平台回归无退化；改动贴合"平台适配集中在 platforms.py"约定；未做版本号 bump（发版时按惯例另行处理）。