### PR TITLE
docs: 安装改为 agent 自动执行脚本 + /awesome-novel 统一入口

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -52,21 +52,23 @@ Let AI be your novel writing partner, from world-building to character developme
 
 ## Installation
 
-Pick the command matching your tool and paste it in your terminal:
+**No copy-pasting needed.** Open the AI tool you use (Claude Code / OpenCode / Codex) and tell it:
 
-**Claude Code:**
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh claude-code
-```
+> **Install awesome-novel-skill for me**
 
-**OpenCode:**
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh opencode
-```
+The agent will download the repo and run the prepared installer `./install.sh <platform>` itself:
+
+| Platform | Install location |
+|----------|------------------|
+| Claude Code | `~/.claude/skills/awesome-novel/` |
+| OpenCode | `~/.config/opencode/skills/awesome-novel/` |
+| Codex | `~/.codex/skills/awesome-novel/` |
+
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`).
 
 **Reasonix:**
 
-Reasonix skills are deployed **per-project** (into `.reasonix/skills/`), not globally. Clone the repo and initialize your novel project with init.py:
+Reasonix skills are deployed **per-project** (into `.reasonix/skills/`), not globally — no `install.sh`. Tell Reasonix **"Install awesome-novel-skill for me"** and it will clone the repo and run `init.py` to initialize your novel project directly:
 
 ```bash
 git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill
@@ -74,39 +76,19 @@ python tools/init.py <novel-project-path> --platform reasonix
 cd <novel-project-path> && reasonix code
 ```
 
-**Codex:**
-
-The Codex skill is installed **user-level** (`~/.codex/skills/awesome-novel/`), while agents/skills/knowledge/memory are deployed **project-level** into `.codex/` at init time:
-
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
-python tools/init.py <novel-project-path> --platform codex
-cd <novel-project-path>  # then call @novel-agent in Codex to start writing
-```
-
-Manual installation:
-
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git
-cd awesome-novel-skill
-mkdir -p ~/.claude/skills/awesome-novel
-cp -r agents ~/.claude/skills/awesome-novel/
-cp -r templates ~/.claude/skills/awesome-novel/
-cp -r knowledge ~/.claude/skills/awesome-novel/
-cp -r memory ~/.claude/skills/awesome-novel/
-cp -r tools ~/.claude/skills/awesome-novel/
-cp SKILL.md ~/.claude/skills/awesome-novel/
-```
-
-You'll see "安装完成" (Installation complete) when done.
+> Use `--genre <number>` to pick a preset genre; without it, init.py asks interactively.
 
 ## Start Writing
 
-After installation, open your terminal in the directory where you want your novel project and launch your AI tool. Then say:
+After the skill is installed, launch Claude Code / OpenCode / Codex in the directory where you want your novel project and type:
 
-> **"帮我写本小说"** (Help me write a novel)
+> **/awesome-novel**
 
-The Agent will guide you through the rest. The system uses 7 AI agents working together — novel-agent (the director) dispatches specialized sub-agents based on progress:
+(In Codex, type `/use awesome-novel`, or just say **"帮我写本小说"**.)
+
+The skill detects the directory state: for a new directory it confirms with you, then runs `init.py` to scaffold the novel workspace locally (project skeleton, agent definitions, knowledge base, memory files) before entering the writing flow. The system uses 7 AI agents working together — novel-agent (the director) dispatches specialized sub-agents based on progress:
+
+Reasonix users: run `reasonix code` in the project directory, then type `/awesome-novel` or `@novel-agent` to enter the writing flow.
 
 ```
 novel-agent (top-level entry — loaded via @novel-agent)
@@ -204,7 +186,7 @@ After chapter one, Agent asks "下一章继续吗？" (Continue to next chapter?
 
 | You Say | AI Does |
 |---------|---------|
-| "帮我写本小说" | Create project from scratch + start setting discussion |
+| "/awesome-novel" or "帮我写本小说" | Load the skill, initialize the novel workspace in the current directory + start setting discussion |
 | "帮我继续写" | Resume from last progress |
 | "写下一章" | Start writing latest chapter |
 | "改一下第 X 段" | Revise specified paragraph |
@@ -235,7 +217,7 @@ Agent asks if you want to choose one during setup.
 
 **Q: I'm not a programmer, can I install it?**
 
-Yes. Just copy and paste those commands into your terminal. The only requirement is having Claude Code, OpenCode, Reasonix, or Codex installed.
+Yes. Tell your AI tool "帮我安装 awesome-novel-skill" — the agent runs the installer for you. The only requirement is having Claude Code, OpenCode, Reasonix, or Codex installed.
 
 **Q: I upgraded the skill, how do I migrate my existing novel projects to the new format?**
 
@@ -259,23 +241,21 @@ This skill also supports [Codex](https://developers.openai.com/codex) (OpenAI's 
 
 ### Install
 
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
-```
-
-Installs to `~/.codex/skills/awesome-novel/`.
+Tell Codex "帮我安装 awesome-novel-skill" and it runs `./install.sh codex` itself, installing to `~/.codex/skills/awesome-novel/`.
 
 ### Initialize a project
 
+Open the target directory in Codex and type `/use awesome-novel` (or say "帮我写本小说") — the skill initializes automatically. You can also run:
+
 ```bash
-python tools/init.py <novel-project-path> --genre <number> --platform codex
+python ~/.codex/skills/awesome-novel/tools/init.py <novel-project-path> --genre <number> --platform codex
 ```
 
 The 8 custom agents are deployed as Codex TOML files (`.codex/agents/*.toml`, with `name` / `description` / `developer_instructions`), standalone tools as `.codex/skills/<name>/SKILL.md`, and anti-AI rules, style preferences, format specs, and writing memory land in `.codex/knowledge/` / `.codex/memory/`.
 
 ### Start writing
 
-Open the project directory in Codex and call `@novel-agent` to enter the writing loop. In Codex, novel-agent dispatches sub-agents with `spawn_agent` (agent name = the TOML name under `.codex/agents/`); the order-file protocol is identical to the other platforms.
+Call `/awesome-novel` or `@novel-agent` to enter the writing loop. In Codex, novel-agent dispatches sub-agents with `spawn_agent` (agent name = the TOML name under `.codex/agents/`); the order-file protocol is identical to the other platforms.
 
 Upgrade later with `python tools/sync-project.py <novel-project-path> --platform codex`.
 

--- a/README-en.md
+++ b/README-en.md
@@ -64,7 +64,7 @@ The agent will download the repo and run the prepared installer `./install.sh <p
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`).
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms).
 
 **Reasonix:**
 

--- a/README-en.md
+++ b/README-en.md
@@ -86,9 +86,9 @@ After the skill is installed, launch Claude Code / OpenCode / Codex in the direc
 
 (In Codex, type `/use awesome-novel`, or just say **"帮我写本小说"**.)
 
-The skill detects the directory state: for a new directory it confirms with you, then runs `init.py` to scaffold the novel workspace locally (project skeleton, agent definitions, knowledge base, memory files) before entering the writing flow. The system uses 7 AI agents working together — novel-agent (the director) dispatches specialized sub-agents based on progress:
+The skill detects the directory state: for a new directory it confirms with you, then runs `init.py` to scaffold the novel workspace locally (project skeleton, agent definitions, knowledge base, memory files) before entering the writing flow. The system uses 8 AI agents working together — novel-agent (the director) dispatches specialized sub-agents based on progress:
 
-Reasonix users: run `reasonix code` in the project directory, then type `/awesome-novel` or `@novel-agent` to enter the writing flow.
+Reasonix users: run `reasonix code` in the project directory, then type `@novel-agent` to enter the writing flow.
 
 ```
 novel-agent (top-level entry — loaded via @novel-agent)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cd <小说项目路径> && reasonix code
 
 skill 会自动检测目录状态：新目录会先和你确认，然后运行 `init.py` 在本地初始化小说工作空间（项目骨架、agent 定义、知识库、记忆文件），完成后进入写作流程。后续再进入该项目时，说 `@novel-agent` 或 **"帮我继续写"** 就能从中断处恢复。
 
-Reasonix 用户在项目目录运行 `reasonix code` 后，同样输入 `/awesome-novel` 或 `@novel-agent` 进入写作流程。
+Reasonix 用户在项目目录运行 `reasonix code` 后，输入 `@novel-agent` 进入写作流程。
 
 Agent 会引导你完成后续步骤。系统由 8 个 AI Agent 协作驱动，自动检测进度、调度任务，你只需确认方向和审阅内容。
 
@@ -435,7 +435,7 @@ OpenCode 项目与 Claude Code 项目结构一致，唯一区别是 agent 定义
 
 ### 初始化项目
 
-在项目目录（或指定路径）运行 init.py，指定 Reasonix 平台；也可对 Reasonix 说 `/awesome-novel` 让它自动完成：
+在项目目录（或指定路径）运行 init.py，指定 Reasonix 平台：
 
 ```bash
 python tools/init.py <小说项目路径> --genre <编号> --platform reasonix
@@ -449,7 +449,7 @@ python tools/init.py <小说项目路径> --genre <编号> --platform reasonix
 cd <小说项目路径> && reasonix code
 ```
 
-然后输入 `/awesome-novel` 或 `@novel-agent` 进入写作循环。Reasonix 环境里 novel-agent 用 `run_skill` 调度子 agent，调度协议与其余平台一致。
+然后输入 `@novel-agent` 进入写作循环。Reasonix 环境里 novel-agent 用 `run_skill` 调度子 agent，调度协议与其余平台一致。
 
 ### 项目结构差异
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ AI 会自动下载仓库，并运行准备好的安装脚本 `./install.sh <平�
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）。
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。
 
 **Reasonix：**
 

--- a/README.md
+++ b/README.md
@@ -74,19 +74,23 @@
 
 ## 安装
 
-**Claude Code：**
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh claude-code
-```
+**不用复制粘贴命令。** 打开你正在使用的 AI 工具（Claude Code / OpenCode / Codex），对它说：
 
-**OpenCode：**
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh opencode
-```
+> **帮我安装 awesome-novel-skill**
+
+AI 会自动下载仓库，并运行准备好的安装脚本 `./install.sh <平台>`，把 skill 本体装到你机器上：
+
+| 平台 | 安装位置 |
+|------|---------|
+| Claude Code | `~/.claude/skills/awesome-novel/` |
+| OpenCode | `~/.config/opencode/skills/awesome-novel/` |
+| Codex | `~/.codex/skills/awesome-novel/` |
+
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）。
 
 **Reasonix：**
 
-Reasonix 的 skill 是**项目级部署**（装在每个小说项目的 `.reasonix/skills/`），不走 install.sh。克隆仓库后直接用 init.py 初始化小说项目：
+Reasonix 的 skill 是**项目级部署**（装在每个小说项目的 `.reasonix/skills/`），不走 install.sh。对 Reasonix 说 **"帮我安装 awesome-novel-skill"**，它会克隆仓库并用 `init.py` 在你的目标目录直接初始化小说项目：
 
 ```bash
 git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill
@@ -94,49 +98,26 @@ python tools/init.py <小说项目路径> --platform reasonix
 cd <小说项目路径> && reasonix code
 ```
 
-> 用 `--genre <编号>` 指定预置题材，不传则交互式选题材。装好后在项目目录里输入 `@novel-agent` 开始写作。
-
-**Codex：**
-
-Codex 的 skill 是**用户级安装**（`~/.codex/skills/awesome-novel/`），小说项目内的 agents/skills/knowledge/memory 则在初始化时**项目级部署**到 `.codex/`：
-
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
-python tools/init.py <小说项目路径> --platform codex
-cd <小说项目路径>  # 然后在 Codex 中调用 @novel-agent 开始写作
-```
-
-或者手动复制（以 Claude Code 为例）：
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git
-cd awesome-novel-skill
-mkdir -p ~/.claude/skills/awesome-novel
-cp -r agents ~/.claude/skills/awesome-novel/
-cp -r skills ~/.claude/skills/awesome-novel/
-cp -r templates ~/.claude/skills/awesome-novel/
-cp -r knowledge ~/.claude/skills/awesome-novel/
-[ -d memory ] && cp -r memory ~/.claude/skills/awesome-novel/
-cp -r tools ~/.claude/skills/awesome-novel/
-cp SKILL.md ~/.claude/skills/awesome-novel/
-echo "安装完成!"
-```
+> 用 `--genre <编号>` 指定预置题材，不传则交互式选题材。
 
 > **OpenCode 用户注意：** 安装路径为 `~/.config/opencode/skills/awesome-novel/`，初始化后 agent 定义部署在项目 `.opencode/agents/` 下，OpenCode 自动发现。详情见下方 [OpenCode 集成](#opencode) 说明。
 
 > **Codex 用户注意：** skill 安装到 `~/.codex/skills/awesome-novel/`，初始化后 8 个自定义 agent 以 TOML 形式部署在项目 `.codex/agents/` 下，Codex 自动发现。详情见下方 [Codex 集成](#codex-集成) 说明。
-
-看到 "安装完成" 就可以了。
 
 > **看到这个项目觉得有用？** 顺手点个 Star，这样它会出现在你的 GitHub 首页，让更多人发现。
 > {: .prompt-info }
 
 ## 开始写小说
 
-安装后，打开终端，在**你想放小说项目的目录**下启动 Claude Code、OpenCode 或 Reasonix，然后说一句：
+安装好本体后，在**你想放小说项目的目录**下启动 Claude Code / OpenCode / Codex，输入：
 
-> **帮我写本小说**
+> **/awesome-novel**
 
-系统会自动加载写作流程。后续再进入该项目时，说 `@novel-agent` 或 **"帮我继续写"** 就能从中断处恢复。
+（Codex 输入 `/use awesome-novel`，或者直接说 **"帮我写本小说"**。）
+
+skill 会自动检测目录状态：新目录会先和你确认，然后运行 `init.py` 在本地初始化小说工作空间（项目骨架、agent 定义、知识库、记忆文件），完成后进入写作流程。后续再进入该项目时，说 `@novel-agent` 或 **"帮我继续写"** 就能从中断处恢复。
+
+Reasonix 用户在项目目录运行 `reasonix code` 后，同样输入 `/awesome-novel` 或 `@novel-agent` 进入写作流程。
 
 Agent 会引导你完成后续步骤。系统由 8 个 AI Agent 协作驱动，自动检测进度、调度任务，你只需确认方向和审阅内容。
 
@@ -250,7 +231,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 
 | 你说 | AI 做什么 |
 |------|-----------|
-| "帮我写本小说" | 首次加载技能 + 创建项目 + 设定讨论 |
+| "/awesome-novel" 或 "帮我写本小说" | 加载技能 + 在当前目录初始化小说工作空间 + 设定讨论 |
 | "@novel-agent" 或 "帮我继续写" | 进入 / 恢复写作循环 |
 | "写下一章" | 开始写最新一章 |
 | "跑一下推演" 或 "剧情推演" | 角色推演沙盘——卡剧情时让角色演一遍 |
@@ -280,7 +261,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 
 **Q: 我不会编程，能装吗？**
 
-能。上面那几行命令复制粘贴到终端，回车就行。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix 或 Codex。
+能。打开你的 AI 工具，对它说"帮我安装 awesome-novel-skill"，AI 会自己运行安装脚本，全程不用复制粘贴命令。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix 或 Codex。
 
 **Q: 我升级了技能，之前写的小说项目怎么迁移到新格式？**
 
@@ -399,15 +380,11 @@ awesome-novel-skill/
 
 ### 安装
 
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh opencode
-```
-
-安装到 `~/.config/opencode/skills/awesome-novel/`。
+在 OpenCode 里输入 **"帮我安装 awesome-novel-skill"**，它会自动运行 `./install.sh opencode`，安装到 `~/.config/opencode/skills/awesome-novel/`。
 
 ### 初始化项目
 
-在目标目录运行 init.py（使用完整路径或设置 `NOVEL_SKILL_HOME` 环境变量）：
+在目标目录输入 `/awesome-novel`，skill 会自动调用 init.py 初始化；也可手动运行：
 
 ```bash
 python ~/.config/opencode/skills/awesome-novel/tools/init.py . --genre <编号>
@@ -415,7 +392,7 @@ python ~/.config/opencode/skills/awesome-novel/tools/init.py . --genre <编号>
 
 ### 开始写作
 
-初始化完成后，在 OpenCode 中通过 `@novel-agent` 或 Task 工具调用 novel-agent 进入写作循环。
+初始化完成后，在 OpenCode 中通过 `/awesome-novel` 或 `@novel-agent` 进入写作循环。
 
 ### 项目结构差异
 
@@ -454,13 +431,11 @@ OpenCode 项目与 Claude Code 项目结构一致，唯一区别是 agent 定义
 
 ### 安装框架源码
 
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill
-```
+对 Reasonix 说 **"帮我安装 awesome-novel-skill"**，它会克隆仓库到本地（项目级部署，不装到全局）。
 
 ### 初始化项目
 
-在项目目录（或指定路径）运行 init.py，指定 Reasonix 平台：
+在项目目录（或指定路径）运行 init.py，指定 Reasonix 平台；也可对 Reasonix 说 `/awesome-novel` 让它自动完成：
 
 ```bash
 python tools/init.py <小说项目路径> --genre <编号> --platform reasonix
@@ -474,7 +449,7 @@ python tools/init.py <小说项目路径> --genre <编号> --platform reasonix
 cd <小说项目路径> && reasonix code
 ```
 
-然后通过 `@novel-agent` 进入写作循环。Reasonix 环境里 novel-agent 用 `run_skill` 调度子 agent，调度协议与其余平台一致。
+然后输入 `/awesome-novel` 或 `@novel-agent` 进入写作循环。Reasonix 环境里 novel-agent 用 `run_skill` 调度子 agent，调度协议与其余平台一致。
 
 ### 项目结构差异
 
@@ -499,23 +474,21 @@ Reasonix 项目把 agent 定义以 skill 形式部署在 `.reasonix/skills/`，�
 
 ### 安装
 
-```bash
-git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex
-```
-
-安装到 `~/.codex/skills/awesome-novel/`。
+在 Codex 里输入 **"帮我安装 awesome-novel-skill"**，它会自动运行 `./install.sh codex`，安装到 `~/.codex/skills/awesome-novel/`。
 
 ### 初始化项目
 
+在 Codex 中打开目标目录，输入 `/use awesome-novel`（或说"帮我写本小说"），skill 会自动初始化；也可手动运行：
+
 ```bash
-python tools/init.py <小说项目路径> --genre <编号> --platform codex
+python ~/.codex/skills/awesome-novel/tools/init.py <小说项目路径> --genre <编号> --platform codex
 ```
 
 初始化后 8 个自定义 agent 以 Codex 官方 TOML 格式部署到项目 `.codex/agents/*.toml`（`name` / `description` / `developer_instructions`），独立交互工具（memory-recording、roleplay-sandbox）部署为 `.codex/skills/<name>/SKILL.md`，反 AI 规则、文风偏好、格式规范与写作记忆分别落在 `.codex/knowledge/`、`.codex/memory/`。
 
 ### 开始写作
 
-在 Codex 中打开项目目录，调用 `@novel-agent` 进入写作循环。Codex 环境里 novel-agent 用 `spawn_agent` 调度子 agent（agent 名 = `.codex/agents/*.toml` 的 name），order 文件协议与其余平台一致。
+初始化完成后，在 Codex 中调用 `/awesome-novel` 或 `@novel-agent` 进入写作循环。Codex 环境里 novel-agent 用 `spawn_agent` 调度子 agent（agent 名 = `.codex/agents/*.toml` 的 name），order 文件协议与其余平台一致。
 
 ### 项目结构差异
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,6 +7,8 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 
 和 AI 一起写小说。本 skill 负责项目状态检测、新项目初始化、旧版项目自动迁移，完成后将控制权交给 novel-agent。
 
+**唤起方式：** 用户在项目目录输入 `/awesome-novel`（Claude Code / OpenCode 直接输入；Codex 输入 `/use awesome-novel`；或说"帮我写本小说"）即进入下方检测流程。新目录会先询问作者，确认后运行 `init.py` 在本地初始化小说工作空间。
+
 ## OpenCode 集成说明
 
 本 skill 也支持 OpenCode。安装在 `~/.config/opencode/skills/awesome-novel/` 后，项目初始化脚本会自动部署 agent 定义到 `.opencode/agents/`，OpenCode 即可自动发现：
@@ -28,10 +30,10 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 ## 检测流程 — 严格按此执行，禁止跳过
 
 ```
-检测项目状态
+用户输入 /awesome-novel（或"帮我写本小说"）→ 检测项目状态
 ├─ story.yaml 存在 → 旧版 2.x → 执行自动迁移（见下文）
 ├─ story.md 不存在 → 询问作者是否初始化 → 是则执行 init.py
-│   └─ python tools/init.py [project-path] [--genre <编号>] → 完成后 @novel-agent
+│   └─ python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>] → 完成后 @novel-agent
 └─ story.md 存在 → 已有项目
     ├─ 检查同步新鲜度
     │   ├─ python tools/sync-project.py . --check → exit 0 → 已最新，略过
@@ -57,8 +59,10 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 
 全新项目先询问作者是否初始化，确认后运行 `init.py`（项目路径可选，默认当前目录）：
 ```
-python tools/init.py [project-path] [--genre <编号>]
+python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>]
 ```
+
+`<本 skill 安装目录>` 即本 SKILL.md 所在目录（如 `~/.claude/skills/awesome-novel/`、`~/.config/opencode/skills/awesome-novel/`、`~/.codex/skills/awesome-novel/`）。AI 用绝对路径调用，避免在项目目录找不到 `tools/init.py`。
 
 **禁止以任何理由跳过 init.py：** 手动创建目录、复制模板、直接调用 agent 都属于违规行为。`init.py` 是初始化入口，必须执行且完整运行。
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,13 +36,13 @@ description: 和 AI 协作写小说的工作流系统。8 个 agent 协作完成
 │   └─ python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>] → 完成后 @novel-agent
 └─ story.md 存在 → 已有项目
     ├─ 检查同步新鲜度
-    │   ├─ python tools/sync-project.py . --check → exit 0 → 已最新，略过
-    │   ├─ python tools/sync-project.py . --check → exit 1 → 有更新
+    │   ├─ python <本 skill 安装目录>/tools/sync-project.py . --check → exit 0 → 已最新，略过
+    │   ├─ python <本 skill 安装目录>/tools/sync-project.py . --check → exit 1 → 有更新
     │   │   └─ 展示变更文件，询问作者是否同步
-    │   │       ├─ 确认 → 运行 python tools/sync-project.py .
+    │   │       ├─ 确认 → 运行 python <本 skill 安装目录>/tools/sync-project.py .
     │   │       └─ 跳过 → 继续
     │   └─ .agent/.sync-fingerprint 不存在（首次）
-    │       └─ 静默运行 python tools/sync-project.py . → 写入指纹
+    │       └─ 静默运行 python <本 skill 安装目录>/tools/sync-project.py . → 写入指纹
     └─ → @novel-agent 继续写作
 ```
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -38,8 +38,19 @@
 **AI 会帮你：**
 
 1. 下载最新版本
-2. 执行安装脚本
+2. 运行对应平台的安装脚本（`./install.sh <平台>`）安装 skill 本体
 3. 配置到你的 AI 工具中
+
+---
+
+**安装脚本支持的平台：**
+
+| 平台 | 命令 |
+|------|------|
+| Claude Code | `./install.sh claude-code` |
+| OpenCode | `./install.sh opencode` |
+| Codex | `./install.sh codex` |
+| Reasonix | 项目级部署：`python tools/init.py <项目路径> --platform reasonix`（不走 install.sh） |
 
 ---
 
@@ -49,26 +60,15 @@
 
 ---
 
-**安装脚本支持的平台：**
-
-| 平台 | 命令 |
-|------|------|
-| Claude Code | `./install.sh claude-code` |
-| DeepSeek TUI | `./install.sh deepseek-tui` |
-| Hermes | `./install.sh hermes` |
-| OpenClaw | `./install.sh openclaw` |
-
----
-
 ### 1.3 验证安装
 
-安装完成后，打开你的 AI 工具，说：
+安装完成后，在你想放小说项目的目录打开你的 AI 工具，输入：
 
 ```
-@novel-agent
+/awesome-novel
 ```
 
-如果出现小说写作相关的引导，说明安装成功。
+skill 会先确认并初始化小说工作空间；如果出现小说写作相关的引导，说明安装成功。
 
 ---
 
@@ -79,12 +79,14 @@
 在你的 AI 工具中输入：
 
 ```
-@novel-agent
+/awesome-novel
 ```
 
 或直接说：
 
 > 帮我写一本小说
+
+Codex 中输入 `/use awesome-novel`。
 
 ### 2.2 系统自动检测
 
@@ -109,10 +111,10 @@ AI 检测到是新项目，开始初始化：
 
 > "我来引导你完成小说设定。先确认项目基本信息。"
 
-**【AI】** 执行 init.py：
+**【AI】** 执行 init.py（本 skill 安装目录下的 `tools/init.py`，AI 会自动定位）：
 
 ```bash
-python $NOVEL_SKILL_HOME/tools/init.py
+python <本 skill 安装目录>/tools/init.py
 ```
 
 `init.py` 会自动创建项目骨架，无需额外参数。

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -52,6 +52,8 @@
 | Codex | `./install.sh codex` |
 | Reasonix | 项目级部署：`python tools/init.py <项目路径> --platform reasonix`（不走 install.sh） |
 
+> `install.sh` 同时兼容 deepseek-tui / hermes / openclaw；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。
+
 ---
 
 **如果 AI 说不知道这个项目，再试试：**
@@ -1636,5 +1638,5 @@ AI 会指出具体问题，修改后重新验收。
 
 ---
 
-**手册版本：** v6.1
-**适用版本：** awesome-novel-skill v3.2.3+
+**手册版本：** v4.12.0
+**适用版本：** awesome-novel-skill v4.12.0+

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -31,7 +31,7 @@
 
 ---
 
-> **关于多 Agent 协作架构：** 本系统由 7 个 Agent 协作驱动。`@novel-agent` 是顶层入口，由主 AI 加载后扮演总指挥角色。它不直接写内容，而是通过 Agent 工具调度子 agent（volume-planner / chapter-planner / prompt-crafter / writer / reader / updater）各司其职。子 agent 完成后清理任务标记，novel-agent 检测到后自动推进下一阶段。
+> **关于多 Agent 协作架构：** 本系统由 8 个 Agent 协作驱动。`@novel-agent` 是顶层入口，由主 AI 加载后扮演总指挥角色。它不直接写内容，而是通过 Agent 工具调度子 agent（volume-planner / chapter-planner / prompt-crafter / writer / reader / anti-ai / updater）各司其职。子 agent 完成后清理任务标记，novel-agent 检测到后自动推进下一阶段。
 
 ---
 
@@ -56,7 +56,9 @@
 
 **如果 AI 说不知道这个项目，再试试：**
 
-> "去 https://github.com/modoojunko/awesome-novel-skill/releases 下载最新的 release，然后运行 install.sh"
+> "去 https://github.com/modoojunko/awesome-novel-skill/releases 下载最新的 release，然后按 README 安装"
+
+（Reasonix 不走 install.sh：克隆后用 `python tools/init.py <项目路径> --platform reasonix` 初始化。）
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -97,24 +97,22 @@
     <div class="install">
       <h2>快速安装</h2>
 
-      <p style="margin-top: 1rem;"><span class="badge">Claude Code</span></p>
-      <pre><code>git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh claude-code</code></pre>
+      <p style="margin-top: 1rem;">打开你的 AI 工具，对它说：</p>
+      <pre><code>帮我安装 awesome-novel-skill</code></pre>
 
-      <p style="margin-top: 1rem;"><span class="badge">OpenCode</span></p>
-      <pre><code>git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh opencode</code></pre>
-
-      <p style="margin-top: 1rem;"><span class="badge">Codex</span></p>
-      <pre><code>git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill && ./install.sh codex</code></pre>
-
-      <p style="margin-top: 1rem;"><span class="badge">Reasonix</span>（项目级部署，不走 install.sh）</p>
-      <pre><code>git clone https://github.com/modoojunko/awesome-novel-skill.git && cd awesome-novel-skill
-python tools/init.py &lt;小说项目路径&gt; --platform reasonix
-cd &lt;小说项目路径&gt; && reasonix code</code></pre>
+      <p style="margin-top: 1rem;">AI 会自动运行准备好的安装脚本，把 skill 本体装好：</p>
+      <p style="margin-top: 1rem;">
+        <span class="badge">Claude Code</span> ./install.sh claude-code
+        <span class="badge">OpenCode</span> ./install.sh opencode
+        <span class="badge">Codex</span> ./install.sh codex
+        <span class="badge">Reasonix</span> 项目级部署（init.py --platform reasonix）
+      </p>
     </div>
 
     <h2>开始创作</h2>
-    <p>安装完成后，在你想放小说项目的目录下启动 AI 工具，然后说一句：</p>
-    <pre><code>帮我写本小说</code></pre>
+    <p>安装完成后，在你想放小说项目的目录下启动 AI 工具，输入：</p>
+    <pre><code>/awesome-novel</code></pre>
+    <p>Codex 输入 <code>/use awesome-novel</code>，或直接说"帮我写本小说"。skill 会在本地自动初始化小说工作空间。</p>
 
     <footer>
       <p>GPLv3 开源 · 个人使用免费</p>


### PR DESCRIPTION
## 改了什么

- README（中/英）、landing page、tutorial、SKILL.md 的安装方式从\u201c用户复制粘贴命令\u201d改为\u201c对 AI 说『帮我安装 awesome-novel-skill』，AI 自己运行准备好的 `./install.sh <平台>` 安装本体\u201d。
- 安装完成后统一入口：用户在小说目录输入 `/awesome-novel`（Codex 用 `/use awesome-novel`）初始化本地小说工作空间。
- SKILL.md 检测流程与初始化命令改为 `<本 skill 安装目录>/tools/init.py`（绝对路径），避免在项目目录找不到脚本。

## 为什么改

安装体验目前几乎全靠用户复制粘贴命令，门槛高；改为 agent 驱动安装 + 统一命令入口后，用户只需一句话。

## 测试方式

- 纯文档/HTML 改动，无代码逻辑变更
- Markdown 代码块围栏配对校验通过
- HTML 标签配对目检通过