### PR TITLE
fix: Codex 子 agent 注入调度硬约束防越权与递归自派

### DIFF
--- a/agents/updater.md
+++ b/agents/updater.md
@@ -74,6 +74,7 @@ knowledge:
   - 不编辑正文草稿与中间稿（`.draft.md`/`.anti-ai.md` 一字不改）；归档时仅 Write 生成定稿 `.md`（复制内容，不做内容编辑）
   - 不做创作性决策（不判断好坏，只提取差异）
   - 不调度其他 agent
+  - 不写 `.agent/status.md` 的 `phase` / `current_step` / `last_volume_completed`（由 novel-agent 写；updater 只推进归档/设定相关进度标记）
 - **Decision Rights:**
   - 自主提取修改模式
   - 自主执行语义合并

--- a/agents/volume-planner.md
+++ b/agents/volume-planner.md
@@ -71,6 +71,7 @@ knowledge:
 - **Out of Scope:**
   - 不写具体章纲（那是 chapter-planner 的事）
   - 不做角色心理细节描写
+  - 不调度其他 agent，不派生子 agent
 - **Decision Rights:**
   - 自主提出卷分割方案
   - 建议每卷的章节数和节奏分布

--- a/templates/AGENTS.codex.md
+++ b/templates/AGENTS.codex.md
@@ -8,6 +8,12 @@
 
 **写作流程：** 设定 → 卷纲 → 章纲 → 提示词 → 正文 → 去AI味 → 验收 → 归档 → 下一章
 
+## 调度边界（最高优先级）
+
+- **唯一调度者：** novel-agent 是唯一允许派生子 agent 的 agent；任何被 spawn 的子 agent 禁止再派生（包括派发同名 agent 的递归派生）。
+- 子 agent 即使持有 spawn_agent 工具也不得使用；需要协作时向 novel-agent 报告，由 novel-agent 调度。
+- novel-agent 每次 spawn 后留意 agent 树，发现子 agent 递归派生立即中断并重派。
+
 **项目结构：**
 - `story.md` — 项目索引 + 主线拆纲
 - `settings/` — 世界观、角色、写作风格、时间线

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -354,6 +354,28 @@ _CODEX_TOOL_MAP = {
     "Agent": "spawn_agent",   # Claude Code Agent 工具 ↔ Codex spawn_agent
 }
 
+# 子 agent 注入段：Codex TOML 无工具白名单字段，只能靠指令文本声明硬约束。
+# 放在 developer_instructions 最顶部，先于源文件正文与 SOP。
+_CODEX_DISPATCH_BAN = """## 调度权限硬约束（最高优先级，先于本文件其余一切指令）
+
+你是执行型子 agent，没有任何调度权。**禁止使用 `spawn_agent` 工具派生子 agent**
+（包括派发与自己同名的 agent，禁止任何形式的递归派生）。你实际拥有完整工具集，
+但这条禁令不因工具可用而失效。
+
+同时禁止：
+- 写 `.agent/task/` 下除本 order 以外的任何文件
+- 写 `.agent/status.md` 的 `phase` / `current_step` / `last_volume_completed` 字段
+  （这些字段只有 novel-agent 能写）
+- 代替 novel-agent 推进流水线（写新 order、更新 phase）
+
+你只做：
+1. 读取 order 文件，执行其中指定的任务
+2. 写 order 的 `outputs` 指向的文件
+3. 完成后把 order 的 `status` 覆盖为 `DONE` 并结束
+
+任务需要其他 agent 协作（如发现需要新增设定/归档/评审）时，不要自己调度——
+在回复中明确告诉 novel-agent"下一步应调度谁、为什么"，由 novel-agent 调度。"""
+
 
 def _toml_escape(s: str) -> str:
     """单行 TOML 基本字符串转义。"""
@@ -387,8 +409,9 @@ def convert_to_codex(text: str, skill_home: Path) -> str:
     """Claude Code agent frontmatter → Codex 自定义 agent TOML。
 
     - 必填字段：name / description / developer_instructions（Codex 官方约定）
-    - tools：Codex agent TOML 无工具白名单字段，改为在指令中声明允许工具；
-      Agent → spawn_agent（调度说明见 novel-agent 适配段）
+    - tools：Codex agent TOML 无工具白名单字段，子 agent 注入「调度权限硬约束」
+      （禁止 spawn_agent / 越权写文件），声明的工具范围仅作提示；
+      Agent → spawn_agent（仅 novel-agent 持有，调度说明见适配段）
     - skills：frontmatter 声明的 SOP 内联进 developer_instructions（与 reasonix 一致）
     - 路径改写：.claude/knowledge、.claude/memory → .codex/ 对应目录
     """
@@ -425,11 +448,26 @@ def convert_to_codex(text: str, skill_home: Path) -> str:
             "chapter-planner / prompt-crafter / anti-ai / reader / updater）\n"
             "- 把 order 文件内容作为任务消息传给子 agent；order 文件协议（status: DONE）不变\n"
             "- 一次只调度一个任务，等 DONE 后再调度下一个；禁止把 novel-agent 本身作为子 agent 调度\n"
+            "- 你是本项目唯一调度者：spawn 后留意 agent 树，子 agent 若尝试再派生，立即 interrupt 并按规范重派\n"
         )
+    else:
+        body = _CODEX_DISPATCH_BAN + "\n\n" + body
 
     tool_line = ""
     if allowed:
-        tool_line = f"\n\n（自动生成）本 agent 允许使用的工具：{'、'.join(allowed)}"
+        if name == "novel-agent":
+            tool_line = (
+                "\n\n（自动生成）本 agent 声明的工具范围："
+                + "、".join(allowed)
+                + "。你是唯一调度者，spawn_agent 只用于调度子 agent，禁止派生 novel-agent 自身。"
+            )
+        else:
+            tool_line = (
+                "\n\n（自动生成）本 agent 声明的工具范围："
+                + "、".join(allowed)
+                + "。Codex 自定义 agent TOML 无工具白名单字段，该声明不裁剪实际工具集；"
+                "真正的约束见上文「调度权限硬约束」的禁止项。"
+            )
     body += tool_line
 
     sop_sections = []

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -218,12 +218,27 @@ def test_init_layout():
         nv = (tmp / ".codex/agents/novel-agent.toml").read_text(encoding="utf-8")
         check("codex novel-agent 调度适配",
               "spawn_agent" in nv and ".codex/agents/" in nv)
+        sub_toml = "".join(
+            f.read_text(encoding="utf-8")
+            for f in sorted((tmp / ".codex/agents").glob("*.toml"))
+            if f.name != "novel-agent.toml"
+        )
+        check("codex 子 agent 注入调度硬约束",
+              "调度权限硬约束" in sub_toml and "spawn_agent" in sub_toml
+              and "禁止使用" in sub_toml,
+              "子 agent TOML 缺少禁止派生指令")
+        check("codex novel-agent 不注入禁调",
+              "调度权限硬约束" not in nv, "novel-agent 是唯一调度者，不应注入禁调")
+        vp = (tmp / ".codex/agents/volume-planner.toml").read_text(encoding="utf-8")
+        check("codex volume-planner 源 OOS 含不调度",
+              "不调度其他 agent" in vp, "volume-planner 源文件缺少不调度声明")
         check("codex skill roleplay-sandbox",
               (tmp / ".codex/skills/roleplay-sandbox/SKILL.md").exists())
         check("codex skill memory-recording",
               (tmp / ".codex/skills/memory-recording/SKILL.md").exists())
         ag = (tmp / "AGENTS.md").read_text(encoding="utf-8")
         check("codex AGENTS.md 指向 .codex/agents", ".codex/agents/" in ag, ag[:200])
+        check("codex AGENTS.md 唯一调度者规则", "唯一调度者" in ag, ag[:400])
         check("codex 无 CLAUDE.md", not (tmp / "CLAUDE.md").exists())
         check("codex 无 AGENTS.codex.md 模板副本",
               not (tmp / "AGENTS.codex.md").exists())


### PR DESCRIPTION
## 背景

Codex 平台演示时发现调度失控：子 agent 越权推进流水线（updater 写 volume-plan-order、推进 status.md phase），volume-planner 递归自派同名子 agent。

根因：Codex 自定义 agent TOML 无工具白名单字段，tools 声明只是 developer_instructions 里的文本，无运行时效力；子 agent 实际持有完整工具集（含 spawn_agent）。

## 改动

- tools/platforms.py：convert_to_codex 为所有子 agent 在 developer_instructions 顶部注入「调度权限硬约束」——禁止 spawn_agent（含同名递归派生）、禁止写非本 order 的 .agent/task/ 文件、禁止写 status.md 的 phase / current_step / last_volume_completed；工具范围声明改为提示性文本。
- agents/volume-planner.md / agents/updater.md：源文件 OOS 补「不调度其他 agent / 不派生子 agent」「不写 status.md 的 phase 等字段」。
- templates/AGENTS.codex.md：新增「调度边界（最高优先级）」段，声明 novel-agent 为唯一调度者。
- tools/test_platforms.py：新增 3 个红绿用例（子 agent 注入硬约束、novel-agent 不注入、AGENTS.md 唯一调度者规则）。

## 验证

- tools/test_platforms.py：94/94 通过
- py_compile / check-agents.py / check-conflicts.py 通过
- claude / opencode / reasonix 重新 init 后无 spawn_agent / 调度边界泄漏

## 说明

此为文本级防线（Codex TOML 不支持工具裁剪）。平台支持子 agent 工具白名单前，可显著降低越权与递归派生概率；运行时根治仍需平台能力。