### PR TITLE
fix: Python 版本要求改为安装阶段 fail-fast 暴露

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -48,6 +48,7 @@ Let AI be your novel writing partner, from world-building to character developme
 ## What You Need
 
 - A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, or **Codex** installed
+- Python 3.9+ (the one bundled with macOS works; 3.11+ recommended)
 - About 1 minute to install
 
 ## Installation
@@ -64,7 +65,7 @@ The agent will download from <https://github.com/modoojunko/awesome-novel-skill>
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms).
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version first (3.9+ required) and aborts with a clear upgrade message instead of failing later when `sync-project.py` runs.
 
 **Reasonix:**
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 ## 你需要什么
 
 - 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix** 或 **Codex** 的电脑
+- Python 3.9+（macOS 系统自带 3.9 即可用；推荐 3.11+）
 - 大概 1 分钟完成安装
 
 
@@ -86,7 +87,7 @@ AI 会自动从仓库 <https://github.com/modoojunko/awesome-novel-skill> 下载
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+），不满足会直接中止并给出升级提示，不会等到 `sync-project.py` 执行时才报错。
 
 **Reasonix：**
 

--- a/install.ps1
+++ b/install.ps1
@@ -36,6 +36,18 @@ switch ($Platform) {
 
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
 
+# Python 版本门槛：在任何目录创建/删除前检查（fail-fast）。
+$PY_BIN = "python"
+if (-not (Get-Command $PY_BIN -ErrorAction SilentlyContinue)) {
+    Write-Host "错误: 未找到 python。请先安装 Python 3.9+（https://www.python.org/downloads/）"
+    exit 1
+}
+& $PY_BIN "$SCRIPT_DIR\tools\check-python.py"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "安装中止：请升级 Python 后重试。"
+    exit 1
+}
+
 Write-Host "安装到: $DEST_DIR"
 
 # 创建目录，已存在则清空

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,22 @@ esac
 DEST="$SKILLS_DIR/awesome-novel"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Python 版本门槛：在任何目录创建/删除前检查（fail-fast）。
+# 版本不满足时安装立即中止，而不是等 init.py / sync-project.py 执行时才报错。
+# 可用 NOVEL_PYTHON 显式指定解释器（如 Homebrew 的 python3.12）。
+PY_BIN="${NOVEL_PYTHON:-}"
+if [ -z "$PY_BIN" ]; then
+    PY_BIN="$(command -v python3 || true)"
+fi
+if [ -z "$PY_BIN" ]; then
+    echo "错误: 未找到 python3。请先安装 Python 3.9+（https://www.python.org/downloads/）"
+    exit 1
+fi
+if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-python.py"; then
+    echo "安装中止：请升级 Python 后重试。"
+    exit 1
+fi
+
 echo "安装到: $DEST"
 export NOVEL_SKILL_HOME="$DEST"
 

--- a/tools/check-python.py
+++ b/tools/check-python.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Python 版本门槛检查（安装阶段 fail-fast 用）。
+
+install.sh / install.ps1 在任何目录创建/删除前调用本脚本，解释器版本不满足
+要求时立即报错退出——版本问题在安装阶段暴露，而不是等 init.py /
+sync-project.py 执行时才以 TypeError / SyntaxError 的形式出现。
+
+用法:
+  python tools/check-python.py             # 检查当前解释器 >= 3.9
+  python tools/check-python.py --min 3.10  # 自定义最低版本（测试用）
+
+返回码:
+  0 = 满足要求
+  1 = 版本过低
+  2 = 参数错误
+"""
+
+import sys
+
+# 项目实际最低版本（tools/*.py 均已验证 3.9 兼容；
+# 新代码若用到更高版本语法，应同步提高这里并在安装阶段暴露）。
+MIN_VERSION = (3, 9)
+
+
+def _label(version: tuple) -> str:
+    return ".".join(str(x) for x in version)
+
+
+def main(argv) -> int:
+    min_version = MIN_VERSION
+    if "--min" in argv:
+        idx = argv.index("--min")
+        if idx + 1 >= len(argv):
+            print("错误: --min 需要一个版本号（如 3.10）", file=sys.stderr)
+            return 2
+        raw = argv[idx + 1]
+        try:
+            parts = tuple(int(x) for x in raw.split(".")[:2])
+            if len(parts) != 2:
+                raise ValueError
+            min_version = parts
+        except ValueError:
+            print(f"错误: --min 需要形如 3.10 的版本号，收到: {raw}", file=sys.stderr)
+            return 2
+
+    current = sys.version_info[:2]
+    if current < min_version:
+        print(
+            f"错误: 需要 Python {_label(min_version)} 或更高版本，当前是 {sys.version.split()[0]}。",
+            file=sys.stderr,
+        )
+        print(
+            "请升级 Python 后重试：https://www.python.org/downloads/"
+            "（macOS 也可运行 `brew install python@3.12`）",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Python {sys.version.split()[0]} 满足要求（>= {_label(min_version)}）。")
+    return 0
+
+
+if __name__ == "__main__":
+    for s in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            s.reconfigure(encoding="utf-8")
+        except AttributeError:
+            pass
+    sys.exit(main(sys.argv[1:]))

--- a/tools/sync-project.py
+++ b/tools/sync-project.py
@@ -20,6 +20,8 @@ Windows 中文路径乱码：
   python tools\\sync-project.py "d:\\novels\\daily\\小说项目"
 """
 
+from __future__ import annotations  # str | None 等注解在 Python 3.9 下延迟求值，避免 import 即 TypeError
+
 import hashlib
 import subprocess
 import sys

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -6,9 +6,10 @@
 
 覆盖：
 - 单元：platforms 模块（配置/检测/引用改写/yaml 预检）
+- 单元：check-python.py 版本门槛（安装阶段 fail-fast）
 - E2E：init.py 各平台布局 + 引用改写 + reasonix 10 个 skill + codex TOML agent（含 tomllib 解析）
 - E2E：sync-project.py 各平台同步 + --check
-- E2E：install.sh 全新 HOME 首次安装（F1 回归）+ 缺 pyyaml 负向场景（F5 回归）
+- E2E：install.sh 全新 HOME 首次安装（F1 回归）+ 版本门槛 fail-fast（P-ver 回归）+ 缺 pyyaml 负向场景（F5 回归）
 """
 
 import os
@@ -120,6 +121,18 @@ def test_yaml_precheck():
               _raises_system_exit(p.ensure_yaml, p.PLATFORMS["reasonix"]))
     finally:
         builtins.__import__ = real_import
+
+
+def test_check_python():
+    """P-ver 回归：check-python.py 在安装阶段暴露版本问题，而不是执行时才报 SyntaxError。"""
+    print("[unit] check-python.py 版本门槛")
+    r = run([sys.executable, str(TOOLS / "check-python.py")])
+    check("当前解释器通过", r.returncode == 0, (r.stdout + r.stderr)[-200:])
+    r = run([sys.executable, str(TOOLS / "check-python.py"), "--min", "99.0"])
+    check("超高门槛拒绝", r.returncode == 1, str(r.returncode))
+    check("拒绝信息含版本号与升级提示",
+          "Python 99.0" in (r.stdout + r.stderr) and "升级" in (r.stdout + r.stderr),
+          (r.stdout + r.stderr)[-300:])
 
 
 def _raises(fn, *a) -> bool:
@@ -335,6 +348,24 @@ def test_install_no_home():
     check("no HOME 报路径异常", "安装目标路径异常" in (r.stdout + r.stderr))
 
 
+def test_install_python_gate():
+    """P-ver 回归：版本检查失败时 install.sh 在创建/删除任何目录前即中止。"""
+    print("[e2e] install.sh Python 版本门槛 fail-fast")
+    with tempfile.TemporaryDirectory() as td:
+        home = Path(td) / "home"
+        home.mkdir()
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env["NOVEL_PYTHON"] = "/bin/false"
+        r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
+                cwd=str(TOOLS.parent), env=env)
+        check("版本门槛拒绝 exit 1", r.returncode == 1, str(r.returncode))
+        check("拒绝信息含安装中止", "安装中止" in (r.stdout + r.stderr),
+              (r.stdout + r.stderr)[-300:])
+        dest = home / ".codex" / "skills" / "awesome-novel"
+        check("拒绝时未创建目标目录", not dest.exists())
+
+
 def test_noyaml_e2e():
     """F5 回归：缺 pyyaml 时 init --platform codex 明确报错退出，不产出损坏 TOML。"""
     print("[e2e] 缺 pyyaml 时 init --platform codex 明确报错")
@@ -357,10 +388,12 @@ def main():
         ("test_rewrite", test_rewrite),
         ("test_config", test_config),
         ("test_yaml_precheck", test_yaml_precheck),
+        ("test_check_python", test_check_python),
         ("test_init_layout", test_init_layout),
         ("test_sync", test_sync),
         ("test_install_fresh_home", test_install_fresh_home),
         ("test_install_no_home", test_install_no_home),
+        ("test_install_python_gate", test_install_python_gate),
         ("test_noyaml_e2e", test_noyaml_e2e),
     ]:
         try:


### PR DESCRIPTION
## 背景

`sync-project.py` 使用了 `str | None` 注解但缺少 `from __future__ import annotations`，在 Python 3.9 下 import 即抛 `TypeError`。版本问题只在执行 `sync-project.py` 时才暴露，安装阶段完全无感知。

## 改动

- 修复意外依赖：`sync-project.py` 补 `from __future__ import annotations`（与 `platforms.py` 一致），Python 3.9 下正常可用。
- 安装阶段 fail-fast：新增 `tools/check-python.py` 版本门槛（默认 3.9+，`--min` 供测试覆盖），`install.sh` / `install.ps1` 在任何目录创建/删除前先检查解释器版本，不满足直接中止并给出升级提示；`NOVEL_PYTHON` 可指定解释器。
- 文档：README / README-en 补充 Python 3.9+ 前置要求。
- 测试：`test_platforms.py` 新增版本门槛单元测试与安装 fail-fast 负向 E2E。

## 验证

- Python 3.9.6：`init` / `sync` / `sync --check` 全通过（修复前 import 即 `TypeError`）。
- 全套测试 100/100 通过。
- `install.sh` 用系统 Python 3.9.6 安装成功；版本不满足时在创建目标目录前中止。
