### PR TITLE
fix: 安装阶段 fail-fast 校验 pyyaml 依赖（opencode/codex）

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -49,6 +49,7 @@ Let AI be your novel writing partner, from world-building to character developme
 
 - A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, or **Codex** installed
 - Python 3.9+ (the one bundled with macOS works; 3.11+ recommended)
+- pyyaml for OpenCode / Codex (`pip install pyyaml`; use `pip install --user pyyaml` if the system Python is permission-restricted)
 - About 1 minute to install
 
 ## Installation
@@ -65,7 +66,7 @@ The agent will download from <https://github.com/modoojunko/awesome-novel-skill>
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version first (3.9+ required) and aborts with a clear upgrade message instead of failing later when `sync-project.py` runs.
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version (3.9+ required) and the pyyaml dependency (opencode / codex only), and aborts with clear messages instead of failing later when `init.py` / `sync-project.py` run.
 
 **Reasonix:**
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 
 - 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix** 或 **Codex** 的电脑
 - Python 3.9+（macOS 系统自带 3.9 即可用；推荐 3.11+）
+- OpenCode / Codex 平台还需 pyyaml（`pip install pyyaml`；系统 Python 权限受限时用 `pip install --user pyyaml`）
 - 大概 1 分钟完成安装
 
 
@@ -87,7 +88,7 @@ AI 会自动从仓库 <https://github.com/modoojunko/awesome-novel-skill> 下载
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
 
-看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+），不满足会直接中止并给出升级提示，不会等到 `sync-project.py` 执行时才报错。
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+）和 pyyaml 依赖（仅 opencode / codex），不满足会直接中止并给出升级 / 安装提示，不会等到 `init.py` / `sync-project.py` 执行时才报错。
 
 **Reasonix：**
 

--- a/install.ps1
+++ b/install.ps1
@@ -48,6 +48,16 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
+# pyyaml 门槛：opencode / codex 的 agent 转换依赖 pyyaml（与 tools/platforms.py
+# ensure_yaml 的运行时规则对齐）；claude-code 纯复制不转换，不需要。
+if ($Platform -in @("opencode", "codex")) {
+    & $PY_BIN "$SCRIPT_DIR\tools\check-yaml.py" $Platform
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "安装中止：缺少 pyyaml。请先执行 pip install pyyaml 后重试。"
+        exit 1
+    }
+}
+
 Write-Host "安装到: $DEST_DIR"
 
 # 创建目录，已存在则清空

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,19 @@ if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-python.py"; then
     exit 1
 fi
 
+# pyyaml 门槛：opencode / codex 的 agent 转换依赖 pyyaml（与 tools/platforms.py
+# ensure_yaml 的运行时规则对齐）；claude 平台纯复制不转换、hermes/openclaw/
+# deepseek-tui 未走 agent 转换，均不需要。缺失时同样在任何目录创建/删除前
+# fail-fast，而不是等 init.py / sync-project.py 执行时才报错。
+case "$PLATFORM" in
+    opencode|codex)
+        if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-yaml.py" "$PLATFORM"; then
+            echo "安装中止：缺少 pyyaml。请先执行 pip install pyyaml（系统 Python 权限受限时可用 pip install --user pyyaml），再重试。"
+            exit 1
+        fi
+        ;;
+esac
+
 echo "安装到: $DEST"
 export NOVEL_SKILL_HOME="$DEST"
 

--- a/tools/check-yaml.py
+++ b/tools/check-yaml.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""pyyaml 门槛检查（安装阶段 fail-fast 用）。
+
+opencode / codex 平台的 agent 转换依赖 pyyaml；install.sh / install.ps1
+在任何目录创建/删除前调用本脚本，缺失时立即中止，而不是等 init.py /
+sync-project.py 执行时才报错。claude 平台纯复制不转换，无需本检查。
+
+用法:
+  python tools/check-yaml.py                # 仅检查当前解释器能否 import yaml
+  python tools/check-yaml.py codex          # 附带平台名，报错信息更具体
+
+返回码:
+  0 = 已安装
+  1 = 缺失（输出 pip install 提示）
+  2 = 参数错误
+"""
+
+import sys
+
+
+def main(argv) -> int:
+    platform = None
+    if len(argv) > 2:
+        print("错误: 最多接受一个平台参数。", file=sys.stderr)
+        return 2
+    if len(argv) == 2:
+        platform = argv[1]
+
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        label = platform or "当前"
+        print(
+            f"错误: {label} 平台需要 pyyaml（pip install pyyaml），"
+            f"当前解释器 {sys.executable} 未安装。",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"pyyaml 已安装（解释器 {sys.executable}）。")
+    return 0
+
+
+if __name__ == "__main__":
+    for s in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            s.reconfigure(encoding="utf-8")
+        except AttributeError:
+            pass
+    sys.exit(main(sys.argv))

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -9,7 +9,7 @@
 - 单元：check-python.py 版本门槛（安装阶段 fail-fast）
 - E2E：init.py 各平台布局 + 引用改写 + reasonix 10 个 skill + codex TOML agent（含 tomllib 解析）
 - E2E：sync-project.py 各平台同步 + --check
-- E2E：install.sh 全新 HOME 首次安装（F1 回归）+ 版本门槛 fail-fast（P-ver 回归）+ 缺 pyyaml 负向场景（F5 回归）
+- E2E：install.sh 全新 HOME 首次安装（F1 回归）+ 版本门槛 fail-fast（P-ver 回归）+ pyyaml 安装门槛 fail-fast（Y-ver 回归）+ 缺 pyyaml 负向场景（F5 回归）
 """
 
 import os
@@ -133,6 +133,29 @@ def test_check_python():
     check("拒绝信息含版本号与升级提示",
           "Python 99.0" in (r.stdout + r.stderr) and "升级" in (r.stdout + r.stderr),
           (r.stdout + r.stderr)[-300:])
+
+
+def test_check_yaml():
+    """Y-ver 回归：check-yaml.py 在安装阶段暴露缺 pyyaml，而不是 init 时才报错。"""
+    print("[unit] check-yaml.py pyyaml 门槛")
+    with tempfile.TemporaryDirectory() as td:
+        (Path(td) / "yaml.py").write_text('raise ImportError("blocked")\n', encoding="utf-8")
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(td) + os.pathsep + env.get("PYTHONPATH", "")
+        r = run([sys.executable, str(TOOLS / "check-yaml.py"), "codex"], env=env)
+        check("缺 yaml exit 1", r.returncode == 1, str(r.returncode))
+        check("缺 yaml 报错含 pyyaml 与 pip 提示",
+              "需要 pyyaml" in (r.stdout + r.stderr)
+              and "pip install pyyaml" in (r.stdout + r.stderr),
+              (r.stdout + r.stderr)[-300:])
+        check("缺 yaml 报错含解释器路径", sys.executable in (r.stdout + r.stderr),
+              (r.stdout + r.stderr)[-300:])
+    with tempfile.TemporaryDirectory() as td:
+        (Path(td) / "yaml.py").write_text("# stub\n", encoding="utf-8")
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(td) + os.pathsep + env.get("PYTHONPATH", "")
+        r = run([sys.executable, str(TOOLS / "check-yaml.py"), "opencode"], env=env)
+        check("有 yaml exit 0", r.returncode == 0, (r.stdout + r.stderr)[-200:])
 
 
 def _raises(fn, *a) -> bool:
@@ -327,8 +350,12 @@ def test_install_fresh_home():
     with tempfile.TemporaryDirectory() as td:
         home = Path(td) / "home"
         home.mkdir()
+        stub = Path(td) / "stub"
+        stub.mkdir()
+        (stub / "yaml.py").write_text("# stub\n", encoding="utf-8")
         env = dict(os.environ)
         env["HOME"] = str(home)
+        env["PYTHONPATH"] = str(stub) + os.pathsep + env.get("PYTHONPATH", "")
         r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
                 cwd=str(TOOLS.parent), env=env)
         check("fresh home install exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
@@ -340,12 +367,17 @@ def test_install_fresh_home():
 def test_install_no_home():
     """P2 回归：HOME 未设置时安装脚本在创建任何目录前即拒绝（报路径异常）。"""
     print("[e2e] install.sh 无 HOME 拒绝安装")
-    env = dict(os.environ)
-    env.pop("HOME", None)
-    r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
-            cwd=str(TOOLS.parent), env=env)
-    check("no HOME exit 1", r.returncode == 1, str(r.returncode))
-    check("no HOME 报路径异常", "安装目标路径异常" in (r.stdout + r.stderr))
+    with tempfile.TemporaryDirectory() as td:
+        stub = Path(td) / "stub"
+        stub.mkdir()
+        (stub / "yaml.py").write_text("# stub\n", encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("HOME", None)
+        env["PYTHONPATH"] = str(stub) + os.pathsep + env.get("PYTHONPATH", "")
+        r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
+                cwd=str(TOOLS.parent), env=env)
+        check("no HOME exit 1", r.returncode == 1, str(r.returncode))
+        check("no HOME 报路径异常", "安装目标路径异常" in (r.stdout + r.stderr))
 
 
 def test_install_python_gate():
@@ -362,6 +394,27 @@ def test_install_python_gate():
         check("版本门槛拒绝 exit 1", r.returncode == 1, str(r.returncode))
         check("拒绝信息含安装中止", "安装中止" in (r.stdout + r.stderr),
               (r.stdout + r.stderr)[-300:])
+        dest = home / ".codex" / "skills" / "awesome-novel"
+        check("拒绝时未创建目标目录", not dest.exists())
+
+
+def test_install_yaml_gate():
+    """Y-ver E2E 回归：缺 pyyaml 时 install.sh codex 在创建目标目录前中止。"""
+    print("[e2e] install.sh pyyaml 门槛 fail-fast")
+    with tempfile.TemporaryDirectory() as td:
+        home = Path(td) / "home"
+        home.mkdir()
+        block = Path(td) / "block"
+        block.mkdir()
+        (block / "yaml.py").write_text('raise ImportError("blocked")\n', encoding="utf-8")
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env["PYTHONPATH"] = str(block) + os.pathsep + env.get("PYTHONPATH", "")
+        r = run(["bash", str(TOOLS.parent / "install.sh"), "codex"],
+                cwd=str(TOOLS.parent), env=env)
+        check("缺 pyyaml 拒绝 exit 1", r.returncode == 1, str(r.returncode))
+        check("缺 pyyaml 报安装中止", "安装中止" in (r.stdout + r.stderr)
+              and "pyyaml" in (r.stdout + r.stderr), (r.stdout + r.stderr)[-300:])
         dest = home / ".codex" / "skills" / "awesome-novel"
         check("拒绝时未创建目标目录", not dest.exists())
 
@@ -389,11 +442,13 @@ def main():
         ("test_config", test_config),
         ("test_yaml_precheck", test_yaml_precheck),
         ("test_check_python", test_check_python),
+        ("test_check_yaml", test_check_yaml),
         ("test_init_layout", test_init_layout),
         ("test_sync", test_sync),
         ("test_install_fresh_home", test_install_fresh_home),
         ("test_install_no_home", test_install_no_home),
         ("test_install_python_gate", test_install_python_gate),
+        ("test_install_yaml_gate", test_install_yaml_gate),
         ("test_noyaml_e2e", test_noyaml_e2e),
     ]:
         try:


### PR DESCRIPTION
## 背景

opencode / codex 平台的 agent 转换依赖 pyyaml，但 install.sh / install.ps1 之前只校验 Python 版本，缺 pyyaml 要等 init.py / sync-project.py 执行时才报错，安装阶段没有任何提示。

## 改动

- 新增 tools/check-yaml.py：检查执行它的解释器能否 import yaml，缺失时给出 pip install pyyaml 提示并退出
- install.sh / install.ps1：在创建/删除任何目录前，对 opencode / codex 平台执行 pyyaml 门槛检查（claude-code 纯复制不需要；hermes / openclaw / deepseek-tui 不走 agent 转换也不需要），与 platforms.py ensure_yaml 的运行时规则对齐
- tools/test_platforms.py：新增 check-yaml.py 单元测试 + install.sh 缺 pyyaml fail-fast E2E（Y-ver 回归）
- README / README-en：补充 pyyaml 前置说明

## 验证

- python tools/test_platforms.py：107 通过 / 0 失败
- 手工验证：系统 Python 缺 yaml 时 install.sh codex 立即中止且不创建目标目录；NOVEL_PYTHON 指向带 yaml 的 venv 时安装成功；claude-code 不受影响