### PR TITLE
feat: 新增 ZCode 平台支持（agents 即 skills，与 Reasonix 同构）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,8 @@
 
 ## 构建、测试与开发命令
 
-无构建步骤。Python 主体仅用标准库；pyyaml 例外：`--platform opencode|reasonix|codex` 的 agent 转换（platforms.py）与 style-distill 卡 frontmatter 解析/校验（style_common.py / style_render.py / check-agents.py）（见 `tools/requirements.txt`，CI 自动安装）：
-
-- `python tools/init.py <项目路径> [--genre N] [--platform claude|opencode|reasonix|codex]` — 初始化小说项目骨架
+无构建步骤。Python 主体仅用标准库；pyyaml 例外：`--platform opencode|reasonix|codex|zcode` 的 agent 转换（platforms.py）与 style-distill 卡 frontmatter 解析/校验（style_common.py / style_render.py / check-agents.py）（见 `tools/requirements.txt`，CI 自动安装）：
+- `python tools/init.py <项目路径> [--genre N] [--platform claude|opencode|reasonix|codex|zcode]` — 初始化小说项目骨架
 - `python tools/sync-project.py <项目路径> --check` — 检查项目是否需要同步（0=最新，1=有更新，2=无效）
 - `python tools/test_platforms.py` — 运行测试（退出码 0=通过）
 - `python tools/check-agents.py` — 校验 agent frontmatter 引用路径
@@ -84,7 +83,7 @@ CI：`.github/workflows/static.yml`，push main 时运行语法/agent/规则检�
 ## 测试指南
 
 - 无第三方测试框架；`tools/test_platforms.py` 自写断言，stdout 打印 `ok/FAIL`，非 0 退出码表示失败。
-- 测试函数以 `test_` 开头；E2E 用临时目录验证 init/sync 在 claude/opencode/reasonix/codex 四平台的输出。
+- 测试函数以 `test_` 开头；E2E 用临时目录验证 init/sync 在 claude/opencode/reasonix/codex/zcode 五平台的输出。
 - 涉及 agent 定义跑 `check-agents.py`，涉及反 AI 规则跑 `check-conflicts.py`。
 - 行为变更遵循先红后绿：先加失败用例，再实现（见 `docs/superpowers/` 计划）。
 
@@ -92,7 +91,7 @@ CI：`.github/workflows/static.yml`，push main 时运行语法/agent/规则检�
 
 - 提交信息遵循 Conventional Commits + 中文描述：`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `chore:`，如 `fix: sync-project --platform 值守卫防吞 --check`。
 - 发版时 `chore: bump version to vX.Y.Z`，同步更新 `VERSION` 与 `docs/releasenote-*`。
-- PR：从 main 新建分支，禁止直接改 main；单个 PR 聚焦一项改动并关联 issue；提交前至少在一种 AI 终端实测（claude/opencode/reasonix/codex）。
+- PR：从 main 新建分支，禁止直接改 main；单个 PR 聚焦一项改动并关联 issue；提交前至少在一种 AI 终端实测（claude/opencode/reasonix/codex/zcode）。
 
 ## 安全与配置提示
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,8 +148,8 @@ Skill 入口（主 agent 加载 SKILL.md 后）先做项目状态检测，之后
 │   ├── task/             # order 文件（临时，完成后 status→DONE 留存待删）
 │   ├── archiving/        # 归档 checkpoint（{chapter}.done，防重放重复）
 │   └── {chapter}-draft-ai.md  # AI 原版快照（审计基线，归档后保留，靠 .done 标记区分过期）
-├── .claude/ 或 .opencode/
-│   ├── agents/           # Agent 定义（init.py 部署）
+├── .claude/ 或 .opencode/ 或 .zcode/
+│   ├── agents/           # Agent 定义（init.py 部署；zcode 无 agents，agents 即 .zcode/skills/）
 │   ├── knowledge/        # 反 AI 规则 / 文风偏好 / 场景方法论 / 永久记忆 / 格式规范
 │   └── memory/           # 动态写作记忆（volume/chapter/prompt/writing）
 ```
@@ -187,6 +187,7 @@ tools/           # init.py（初始化）、sync-project.py（同步更新）
 - **Claude Code**：init.py 部署 agent 定义到 `.claude/agents/`，知识到 `.claude/knowledge/`，建 `.claude/memory/` 动态记忆桩
 - **OpenCode**：init.py 同时部署到 `.opencode/agents/`，OpenCode 自动发现 `@novel-agent` 等
 - **Codex**：init.py 部署 9 个自定义 agent 为 `.codex/agents/*.toml`（TOML 转换产物，引用改写为 `.codex/knowledge|memory`），独立工具为 `.codex/skills/<name>/SKILL.md`；novel-agent 用 `spawn_agent` 调度子 agent
+- **ZCode**：init.py 部署 9 个 agent 为 `.zcode/skills/<name>/SKILL.md`（skill 转换产物，引用改写为 `.zcode/knowledge|memory`；ZCode 无项目级 agents 目录，agents 即 skills，与 Reasonix 同构）；novel-agent 用 `Agent` 工具按 skill 名调度子 agent
 - **安装**：`install.sh` / `install.ps1` 将 skill 装到用户级 skills 目录
 
 ---

--- a/README-en.md
+++ b/README-en.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>Write Novels with Claude Code / OpenCode / Reasonix / Codex</em>
+  <em>Write Novels with Claude Code / OpenCode / Reasonix / Codex / ZCode</em>
 </p>
 
 <p align="center">
@@ -8,6 +8,7 @@
   <a href="https://github.com/sglaboratory/opencode"><img src="https://img.shields.io/badge/OpenCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-4A90D9?style=flat-square" alt="OpenCode"></a>
   <img src="https://img.shields.io/badge/Reasonix-%E2%9C%93%20%E6%94%AF%E6%8C%81-16A34A?style=flat-square" alt="Reasonix">
   <a href="#codex-integration"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
+  <a href="#zcode-integration"><img src="https://img.shields.io/badge/ZCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-0EA5E9?style=flat-square" alt="ZCode"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
 </p>
@@ -47,14 +48,14 @@ Let AI be your novel writing partner, from world-building to character developme
 
 ## What You Need
 
-- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, or **Codex** installed
+- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, **Codex** or **ZCode** installed
 - Python 3.9+ (the one bundled with macOS works; 3.11+ recommended)
-- pyyaml for OpenCode / Codex (`pip install pyyaml`; use `pip install --user pyyaml` if the system Python is permission-restricted)
+- pyyaml for OpenCode / Codex / ZCode (`pip install pyyaml`; use `pip install --user pyyaml` if the system Python is permission-restricted)
 - About 1 minute to install
 
 ## Installation
 
-**No copy-pasting needed.** Open the AI tool you use (Claude Code / OpenCode / Codex) and tell it:
+**No copy-pasting needed.** Open the AI tool you use (Claude Code / OpenCode / Codex / ZCode) and tell it:
 
 > **Install awesome-novel-skill for me**
 
@@ -65,8 +66,9 @@ The agent will download from <https://github.com/modoojunko/awesome-novel-skill>
 | Claude Code | `~/.claude/skills/awesome-novel/` |
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
+| ZCode | `~/.zcode/skills/awesome-novel/` |
 
-You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version (3.9+ required) and the pyyaml dependency (opencode / codex only), and aborts with clear messages instead of failing later when `init.py` / `sync-project.py` run.
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex` / `zcode`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version (3.9+ required) and the pyyaml dependency (opencode / codex / zcode only), and aborts with clear messages instead of failing later when `init.py` / `sync-project.py` run.
 
 **Reasonix:**
 
@@ -80,9 +82,18 @@ cd <novel-project-path> && reasonix code
 
 > Use `--genre <number>` to pick a preset genre; without it, init.py asks interactively.
 
+**ZCode:**
+
+ZCode's skill convention (directory + `SKILL.md`) is compatible with Claude Code's, but it has **no project-level agents directory** — the 9 agents are deployed as skills (agents == skills). The skill itself is installed globally via `install.sh`; project contents are deployed per-project to `.zcode/` by `init.py --platform zcode`:
+
+```bash
+./install.sh zcode
+python ~/.zcode/skills/awesome-novel/tools/init.py <novel-project-path> --platform zcode
+```
+
 ## Start Writing
 
-After the skill is installed, launch Claude Code / OpenCode / Codex in the directory where you want your novel project and type:
+After the skill is installed, launch Claude Code / OpenCode / Codex / ZCode in the directory where you want your novel project and type:
 
 > **/awesome-novel**
 
@@ -90,7 +101,7 @@ After the skill is installed, launch Claude Code / OpenCode / Codex in the direc
 
 The skill detects the directory state: for a new directory it confirms with you, then runs `init.py` to scaffold the novel workspace locally (project skeleton, agent definitions, knowledge base, memory files) before entering the writing flow. The system uses 8 AI agents working together — novel-agent (the director) dispatches specialized sub-agents based on progress:
 
-Reasonix users: run `reasonix code` in the project directory, then type `@novel-agent` to enter the writing flow.
+Reasonix users: run `reasonix code` in the project directory, then type `@novel-agent` to enter the writing flow. ZCode users: just say **"帮我写本小说"** or **"帮我继续写"** in the project directory (ZCode has no `@` syntax — agents are skills and novel-agent is auto-discovered).
 
 ```
 novel-agent (top-level entry — loaded via @novel-agent)
@@ -142,14 +153,18 @@ After setup, the Agent creates your novel project in the current directory:
         ├── chapter-memory.md
         ├── prompt-memory.md
         └── writing-memory.md
-└── .codex/               # Codex: 8 custom agents (TOML) + knowledge + memory
+├── .codex/               # Codex: 8 custom agents (TOML) + knowledge + memory
     ├── agents/           # Custom agent definitions (deployed at init)
     ├── skills/           # Standalone tools (memory-recording, roleplay-sandbox)
     ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
     └── memory/           # Dynamic writing memory (feedback per phase)
+└── .zcode/               # ZCode: 11 skills (agents == skills) + knowledge + memory
+    ├── skills/           # SKILL.md per agent (deployed at init)
+    ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
+    └── memory/           # Dynamic writing memory (feedback per phase)
 ```
 
-All files are plain Markdown — you can open and edit them directly.
+All files are plain Markdown — you can open and edit them directly. Only one platform directory is generated per project (chosen by `init.py --platform`).
 
 ### Planning the Story Framework
 
@@ -260,6 +275,30 @@ The 8 custom agents are deployed as Codex TOML files (`.codex/agents/*.toml`, wi
 Call `/awesome-novel` or `@novel-agent` to enter the writing loop. In Codex, novel-agent dispatches sub-agents with `spawn_agent` (agent name = the TOML name under `.codex/agents/`); the order-file protocol is identical to the other platforms.
 
 Upgrade later with `python tools/sync-project.py <novel-project-path> --platform codex`.
+
+## ZCode Integration
+
+This skill also supports [ZCode](https://zcode.z.ai) (open-source AI coding agent terminal). ZCode's skill convention (directory + `SKILL.md`) is compatible with Claude Code's — **natively supported** — but it has no project-level agents directory, so the 9 agents are deployed as skills (agents == skills). The skill itself is installed **user-level**, while project contents (agents/skills/knowledge/memory) are deployed **project-level** into `.zcode/`.
+
+### Install
+
+Tell ZCode "帮我安装 awesome-novel-skill" and it runs `./install.sh zcode` itself, installing to `~/.zcode/skills/awesome-novel/`.
+
+### Initialize a project
+
+Open the target directory in ZCode and say "帮我写本小说" — the skill initializes automatically. You can also run:
+
+```bash
+python ~/.zcode/skills/awesome-novel/tools/init.py <novel-project-path> --genre <number> --platform zcode
+```
+
+The 9 agents are deployed as `.zcode/skills/<name>/SKILL.md` (11 skills in total, same layout as Reasonix: 9 agents + memory-recording / roleplay-sandbox standalone tools), and anti-AI rules, style preferences, format specs, and writing memory land in `.zcode/knowledge/` / `.zcode/memory/`.
+
+### Start writing
+
+Open the project directory in ZCode and say **"帮我写本小说"** or **"帮我继续写"** to enter the writing loop (ZCode has no `@` syntax — novel-agent is auto-discovered as a skill). In ZCode, novel-agent dispatches sub-agents with the `Agent` tool (sub-agent name = skill name under `.zcode/skills/`); the order-file protocol is identical to the other platforms.
+
+Upgrade later with `python tools/sync-project.py <novel-project-path> --platform zcode`.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix / Codex</em>
+  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix / Codex / ZCode</em>
 </p>
 
 <p align="center">
@@ -9,6 +9,7 @@
   <a href="#opencode"><img src="https://img.shields.io/badge/OpenCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-4A90D9?style=flat-square" alt="OpenCode"></a>
   <a href="#reasonix-集成"><img src="https://img.shields.io/badge/Reasonix-%E2%9C%93%20%E6%94%AF%E6%8C%81-16A34A?style=flat-square" alt="Reasonix"></a>
   <a href="#codex-集成"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
+  <a href="#zcode-集成"><img src="https://img.shields.io/badge/ZCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-0EA5E9?style=flat-square" alt="ZCode"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
   <br>
@@ -68,15 +69,15 @@
 
 ## 你需要什么
 
-- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix** 或 **Codex** 的电脑
+- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix**、**Codex** 或 **ZCode** 的电脑
 - Python 3.9+（macOS 系统自带 3.9 即可用；推荐 3.11+）
-- OpenCode / Codex 平台还需 pyyaml（`pip install pyyaml`；系统 Python 权限受限时用 `pip install --user pyyaml`）
+- OpenCode / Codex / ZCode 平台还需 pyyaml（`pip install pyyaml`；系统 Python 权限受限时用 `pip install --user pyyaml`）
 - 大概 1 分钟完成安装
 
 
 ## 安装
 
-**不用复制粘贴命令。** 打开你正在使用的 AI 工具（Claude Code / OpenCode / Codex），对它说：
+**不用复制粘贴命令。** 打开你正在使用的 AI 工具（Claude Code / OpenCode / Codex / ZCode），对它说：
 
 > **帮我安装 awesome-novel-skill**
 
@@ -87,8 +88,9 @@ AI 会自动从仓库 <https://github.com/modoojunko/awesome-novel-skill> 下载
 | Claude Code | `~/.claude/skills/awesome-novel/` |
 | OpenCode | `~/.config/opencode/skills/awesome-novel/` |
 | Codex | `~/.codex/skills/awesome-novel/` |
+| ZCode | `~/.zcode/skills/awesome-novel/` |
 
-看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+）和 pyyaml 依赖（仅 opencode / codex），不满足会直接中止并给出升级 / 安装提示，不会等到 `init.py` / `sync-project.py` 执行时才报错。
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex` / `zcode`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+）和 pyyaml 依赖（仅 opencode / codex / zcode），不满足会直接中止并给出升级 / 安装提示，不会等到 `init.py` / `sync-project.py` 执行时才报错。
 
 **Reasonix：**
 
@@ -102,16 +104,27 @@ cd <小说项目路径> && reasonix code
 
 > 用 `--genre <编号>` 指定预置题材，不传则交互式选题材。
 
+**ZCode：**
+
+ZCode 的 skill 约定与 Claude Code 同源（目录 + `SKILL.md`），但**无项目级 agents 目录**——项目内的 9 个 agent 以 skill 形式部署（agents 即 skills）。skill 本体走 install.sh 用户级安装，项目内容由 `init.py --platform zcode` 项目级部署到 `.zcode/`：
+
+```bash
+./install.sh zcode
+python ~/.zcode/skills/awesome-novel/tools/init.py <小说项目路径> --platform zcode
+```
+
 > **OpenCode 用户注意：** 安装路径为 `~/.config/opencode/skills/awesome-novel/`，初始化后 agent 定义部署在项目 `.opencode/agents/` 下，OpenCode 自动发现。详情见下方 [OpenCode 集成](#opencode) 说明。
 
 > **Codex 用户注意：** skill 安装到 `~/.codex/skills/awesome-novel/`，初始化后 9 个自定义 agent 以 TOML 形式部署在项目 `.codex/agents/` 下，Codex 自动发现。详情见下方 [Codex 集成](#codex-集成) 说明。
+
+> **ZCode 用户注意：** skill 安装到 `~/.zcode/skills/awesome-novel/`，初始化后 9 个 agent 以 SKILL.md 形式部署在项目 `.zcode/skills/` 下（ZCode 无项目级 agents 目录，agents 即 skills），ZCode 自动发现。详情见下方 [ZCode 集成](#zcode-集成) 说明。
 
 > **看到这个项目觉得有用？** 顺手点个 Star，这样它会出现在你的 GitHub 首页，让更多人发现。
 > {: .prompt-info }
 
 ## 开始写小说
 
-安装好本体后，在**你想放小说项目的目录**下启动 Claude Code / OpenCode / Codex，输入：
+安装好本体后，在**你想放小说项目的目录**下启动 Claude Code / OpenCode / Codex / ZCode，输入：
 
 > **/awesome-novel**
 
@@ -119,7 +132,7 @@ cd <小说项目路径> && reasonix code
 
 skill 会自动检测目录状态：新目录会先和你确认，然后运行 `init.py` 在本地初始化小说工作空间（项目骨架、agent 定义、知识库、记忆文件），完成后进入写作流程。后续再进入该项目时，说 `@novel-agent` 或 **"帮我继续写"** 就能从中断处恢复。
 
-Reasonix 用户在项目目录运行 `reasonix code` 后，输入 `@novel-agent` 进入写作流程。
+Reasonix 用户在项目目录运行 `reasonix code` 后，输入 `@novel-agent` 进入写作流程。ZCode 用户在项目目录说 **"帮我写本小说"** 或 **"帮我继续写"** 即可（ZCode 无 `@` 语法，agents 即 skills，novel-agent 由 ZCode 自动发现）。
 
 Agent 会引导你完成后续步骤。系统由 9 个 AI Agent 协作驱动，自动检测进度、调度任务，你只需确认方向和审阅内容。
 
@@ -167,11 +180,11 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 ├── .agent/               # Agent 进度 + 任务通信
 │   ├── status.md         # 进度标记（phase/volume/chapter）
 │   └── task/             # 子 agent 间 order 文件
-├── .opencode/            # OpenCode 用（四选一，由 init.py --platform 决定）
+├── .opencode/            # OpenCode 用（五选一，由 init.py --platform 决定）
 │   ├── agents/           # 9 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆
-├── .claude/              # Claude Code 用（四选一）
+├── .claude/              # Claude Code 用（五选一）
 │   ├── agents/           # 9 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆（各环节作者反馈）
@@ -179,18 +192,22 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 │       ├── chapter-memory.md
 │       ├── prompt-memory.md
 │       └── writing-memory.md
-├── .reasonix/            # Reasonix 用（四选一）
+├── .reasonix/            # Reasonix 用（五选一）
     ├── skills/           # 11 个 SKILL.md（agents 即 skills）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
-└── .codex/               # Codex 用（四选一）
+├── .codex/               # Codex 用（五选一）
     ├── agents/           # 9 个自定义 agent（TOML，初始化时部署）
     ├── skills/           # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
+└── .zcode/               # ZCode 用（五选一）
+    ├── skills/           # 10 个 SKILL.md（agents 即 skills，初始化时部署）
+    ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
+    └── memory/           # 写作动态记忆
 ```
 
-这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` 不会同时存在。
+这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` 不会同时存在。
 
 ### 规划故事骨架
 
@@ -264,7 +281,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 
 **Q: 我不会编程，能装吗？**
 
-能。打开你的 AI 工具，对它说"帮我安装 awesome-novel-skill，仓库在 https://github.com/modoojunko/awesome-novel-skill"，AI 会自己运行安装脚本，全程不用复制粘贴命令。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix 或 Codex。
+能。打开你的 AI 工具，对它说"帮我安装 awesome-novel-skill，仓库在 https://github.com/modoojunko/awesome-novel-skill"，AI 会自己运行安装脚本，全程不用复制粘贴命令。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix、Codex 或 ZCode。
 
 **Q: 我升级了技能，之前写的小说项目怎么迁移到新格式？**
 
@@ -399,7 +416,7 @@ python ~/.config/opencode/skills/awesome-novel/tools/init.py . --genre <编号>
 
 ### 项目结构差异
 
-OpenCode 项目与 Claude Code 项目结构一致，唯一区别是 agent 定义部署在 `.opencode/agents/` 而非 `.claude/agents/`。三个平台共享同一套写作流程和知识库。
+OpenCode 项目与 Claude Code 项目结构一致，唯一区别是 agent 定义部署在 `.opencode/agents/` 而非 `.claude/agents/`。各平台共享同一套写作流程和知识库。
 
 ### Agent 技能贡献
 
@@ -508,3 +525,42 @@ python ~/.codex/skills/awesome-novel/tools/init.py <小说项目路径> --genre 
 ```
 
 升级时用 `python tools/sync-project.py <小说项目路径> --platform codex` 同步最新框架。
+
+## ZCode 集成
+
+本 skill 也支持 [ZCode](https://zcode.z.ai)（开源的 AI 编码 agent 终端）。ZCode 的 skill 约定（目录 + `SKILL.md`）与 Claude Code 同源，**天然兼容**；但 ZCode 无项目级 agents 目录，项目内 9 个 agent 以 skill 形式部署（agents 即 skills）。skill 本体**用户级安装**，小说项目内的 agents/skills/knowledge/memory 全部**项目级部署**在 `.zcode/`。
+
+### 安装
+
+在 ZCode 里输入 **"帮我安装 awesome-novel-skill"**，它会自动运行 `./install.sh zcode`，安装到 `~/.zcode/skills/awesome-novel/`。
+
+### 初始化项目
+
+在 ZCode 中打开目标目录，说"帮我写本小说"，skill 会自动初始化；也可手动运行：
+
+```bash
+python ~/.zcode/skills/awesome-novel/tools/init.py <小说项目路径> --genre <编号> --platform zcode
+```
+
+初始化后 9 个 agent 以 SKILL.md 形式部署到项目 `.zcode/skills/<name>/SKILL.md`（与 Reasonix 同构，含 11 个 skill：9 个 agent + memory-recording、roleplay-sandbox 独立工具），反 AI 规则、文风偏好、格式规范与写作记忆分别落在 `.zcode/knowledge/`、`.zcode/memory/`。
+
+### 开始写作
+
+初始化完成后，在 ZCode 中打开项目目录，说 **"帮我写本小说"** 或 **"帮我继续写"** 进入写作循环（ZCode 无 `@` 语法，novel-agent 由 ZCode 按 skill 自动发现）。ZCode 环境里 novel-agent 用 `Agent` 工具调度子 agent（子 agent 名 = `.zcode/skills/` 下的 skill 名），order 文件协议与其余平台一致。
+
+### 项目结构差异
+
+```
+.zcode/
+├── skills/               # 11 个 SKILL.md（agents 即 skills）
+│   ├── novel-agent/      # 总指挥（入口调度者）
+│   ├── writer/           # 正文写手（subagent）
+│   ├── volume-planner/   # 卷纲规划（subagent）
+│   ├── ...
+│   ├── memory-recording/ # 独立交互工具
+│   └── roleplay-sandbox/ # 独立交互工具
+├── knowledge/            # 反 AI 规则、文风偏好、永久记忆、格式规范
+└── memory/               # 写作动态记忆
+```
+
+升级时用 `python tools/sync-project.py <小说项目路径> --platform zcode` 同步最新框架。

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,14 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 
 **调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ 用 `spawn_agent` 调度子 agent（agent 名 = `.codex/agents/*.toml` 的 name）→ 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。order 文件协议与其余平台完全一致。
 
+## ZCode 集成说明
+
+本 skill 也支持 ZCode。ZCode 的 skill 约定（目录 + `SKILL.md`）与 Claude Code 同源，天然兼容；但 ZCode 无项目级 agents 目录，agents 即 skills。skill 本体**用户级安装**到 `~/.zcode/skills/awesome-novel/`；`init.py --platform zcode` 初始化小说项目时，把 9 个 agent 部署为项目级 `.zcode/skills/<name>/SKILL.md`（与 Reasonix 同构，另含 memory-recording、roleplay-sandbox 独立工具，共 11 个 skill）：
+- novel-agent — 总指挥（入口调度者，由 ZCode 按描述自动发现，无 `@` 语法）
+- writer、volume-planner、chapter-planner 等 — 子 agent（subagent skill，由 novel-agent 用 Agent 工具按 skill 名 spawn）
+
+**调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ 用 `Agent` 工具调度子 agent（子 agent 名 = `.zcode/skills/` 下的 skill 名）→ 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。order 文件协议与其余平台完全一致。
+
 ## 检测流程 — 严格按此执行，禁止跳过
 
 ```
@@ -52,7 +60,7 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 - 确认后必须运行 `init.py`，禁止手动创建目录结构替代
 - **禁止在 skill 安装目录（含 `skills/awesome-novel` 路径）内运行 `init.py`** — 此目录是技能仓库，不是小说项目
 - 如果当前目录是 skill 安装目录，应提示作者切换到目标目录后再执行
-- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/`），方可进入 `@novel-agent`
+- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/`；ZCode → `.zcode/skills/`），方可进入 novel-agent
 - 如果 `init.py` 报错，必须先修复问题重新执行，不允许绕过
 
 ## 初始化 — 先询问，确认后执行，不可跳过
@@ -62,15 +70,15 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>]
 ```
 
-`<本 skill 安装目录>` 即本 SKILL.md 所在目录（如 `~/.claude/skills/awesome-novel/`、`~/.config/opencode/skills/awesome-novel/`、`~/.codex/skills/awesome-novel/`）。AI 用绝对路径调用，避免在项目目录找不到 `tools/init.py`。
+`<本 skill 安装目录>` 即本 SKILL.md 所在目录（如 `~/.claude/skills/awesome-novel/`、`~/.config/opencode/skills/awesome-novel/`、`~/.codex/skills/awesome-novel/`、`~/.zcode/skills/awesome-novel/`）。AI 用绝对路径调用，避免在项目目录找不到 `tools/init.py`。
 
 **禁止以任何理由跳过 init.py：** 手动创建目录、复制模板、直接调用 agent 都属于违规行为。`init.py` 是初始化入口，必须执行且完整运行。
 
 `init.py` 会：
 1. 选题材
 2. 创建项目骨架（settings/、volumes/、chapters/、prompts/、archives/）
-3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix 不部署 agents，agents 即 `.reasonix/skills/`；Codex → `.codex/agents/*.toml`）
-4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/` / `.codex/knowledge/`）
+3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode 不部署 agents，agents 即 `.reasonix/skills/` / `.zcode/skills/`；Codex → `.codex/agents/*.toml`）
+4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/` / `.codex/knowledge/` / `.zcode/knowledge/`）
 5. 按题材继承格式规范、题材案例到平台 knowledge 目录
 6. 创建空白的写作记忆文件（平台 memory 目录）
 7. 创建永久记忆占位文件（平台 knowledge 目录）
@@ -232,25 +240,29 @@ cp old/prompts/*.txt prompts/ 2>/dev/null
 ├── .agent/
 │   ├── status.md         # 进度追踪
 │   └── task/             # agent 间 order 文件
-├── .claude/             # Claude Code 用（平台一，四选一）
+├── .claude/             # Claude Code 用（平台一，五选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-├── .opencode/           # OpenCode 用（平台二，四选一）
+├── .opencode/           # OpenCode 用（平台二，五选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-├── .reasonix/           # Reasonix 用（平台三，四选一）
+├── .reasonix/           # Reasonix 用（平台三，五选一）
     ├── skills/          # 11 个 SKILL.md（agents 即 skills）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
-└── .codex/              # Codex 用（平台四，四选一）
+├── .codex/              # Codex 用（平台四，五选一）
     ├── agents/          # 9 个自定义 agent（TOML）
     ├── skills/          # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
+└── .zcode/              # ZCode 用（平台五，五选一）
+    ├── skills/          # 11 个 SKILL.md（agents 即 skills）
+    ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
+    └── memory/          # 写作动态记忆
 ```
-> 实际项目只生成四选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` 不会同时存在。
+> 实际项目只生成五选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` 不会同时存在。
 
 ## Agent 协作架构
 
@@ -266,13 +278,13 @@ novel-agent（总指挥）
   └─ 归档完成 → 卷完成判定 → 下一章 / 卷 N+1 / 完本
 ```
 
-各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/*.toml`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
+各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode → `.reasonix/skills/` / `.zcode/skills/`；Codex → `.codex/agents/*.toml`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
 
 **可选工具：** 剧情推演沙盘（`skills/roleplay-sandbox.md`）是独立的交互式工具，不在 agent 调度链中。作者卡剧情时主动调用，产出推演记录（`sandbox/`）供编写章纲时参考。
 
 **调度规则：** novel-agent 是唯一调度者，只写 order 文件 + 调用子 agent。所有内容创作（卷纲/章纲/提示词/正文）、设定维护、归档更新均由子 agent 完成，novel-agent 不得越权代劳。子 agent 完成任务后把 order 覆盖为 `status: DONE`（不删除文件），novel-agent 检测到 DONE 即确认完成。
 
-**重要：novel-agent 是顶层入口，通过 `@novel-agent` 加载进主 agent，禁止通过 Agent 工具将 novel-agent 作为 subagent 调度。** 主 agent 加载 novel-agent 定义后即扮演总指挥角色，拥有完整的 Agent 工具权限来调度子 agent。如果 novel-agent 被作为 subagent 派出，它将失去 Agent 工具调用能力，导致调度链断裂。
+**重要：novel-agent 是顶层入口，通过 `@novel-agent`（Claude Code / OpenCode / Codex）或 ZCode 的 skill 自动发现加载进主 agent，禁止通过 Agent 工具将 novel-agent 作为 subagent 调度。** 主 agent 加载 novel-agent 定义后即扮演总指挥角色，拥有完整的 Agent 工具权限来调度子 agent。如果 novel-agent 被作为 subagent 派出，它将失去 Agent 工具调用能力，导致调度链断裂。
 
 ## 工具契约
 

--- a/install.ps1
+++ b/install.ps1
@@ -16,7 +16,7 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code", "opencode", "codex")]
+    [ValidateSet("claude-code", "opencode", "codex", "zcode")]
     [string]$Platform
 )
 
@@ -31,6 +31,9 @@ switch ($Platform) {
     }
     "codex" {
         $DEST_DIR = "$HOME_DIR\.codex\skills\awesome-novel"
+    }
+    "zcode" {
+        $DEST_DIR = "$HOME_DIR\.zcode\skills\awesome-novel"
     }
 }
 
@@ -48,9 +51,9 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# pyyaml 门槛：opencode / codex 的 agent 转换依赖 pyyaml（与 tools/platforms.py
-# ensure_yaml 的运行时规则对齐）；claude-code 纯复制不转换，不需要。
-if ($Platform -in @("opencode", "codex")) {
+# pyyaml 门槛：opencode / codex / zcode 的 agent/skill 转换依赖 pyyaml（与
+# tools/platforms.py ensure_yaml 的运行时规则对齐）；claude-code 纯复制不转换，不需要。
+if ($Platform -in @("opencode", "codex", "zcode")) {
     & $PY_BIN "$SCRIPT_DIR\tools\check-yaml.py" $Platform
     if ($LASTEXITCODE -ne 0) {
         Write-Host "安装中止：缺少 pyyaml。请先执行 pip install pyyaml 后重试。"

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -e
 
 usage() {
     echo "用法: $0 <平台>"
-    echo "平台: claude-code, opencode, codex, hermes, openclaw, deepseek-tui"
+    echo "平台: claude-code, opencode, codex, zcode, hermes, openclaw, deepseek-tui"
     exit 1
 }
 
@@ -50,6 +50,9 @@ case "$PLATFORM" in
     codex)
         SKILLS_DIR="$HOME/.codex/skills"
         ;;
+    zcode)
+        SKILLS_DIR="$HOME/.zcode/skills"
+        ;;
     *)
         echo "不支持的平台: $PLATFORM"
         usage
@@ -75,12 +78,12 @@ if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-python.py"; then
     exit 1
 fi
 
-# pyyaml 门槛：opencode / codex 的 agent 转换依赖 pyyaml（与 tools/platforms.py
-# ensure_yaml 的运行时规则对齐）；claude 平台纯复制不转换、hermes/openclaw/
-# deepseek-tui 未走 agent 转换，均不需要。缺失时同样在任何目录创建/删除前
-# fail-fast，而不是等 init.py / sync-project.py 执行时才报错。
+# pyyaml 门槛：opencode / codex / zcode 的 agent/skill 转换依赖 pyyaml（与
+# tools/platforms.py ensure_yaml 的运行时规则对齐）；claude 平台纯复制不转换、
+# hermes/openclaw/deepseek-tui 未走转换，均不需要。缺失时同样在任何目录创建/
+# 删除前 fail-fast，而不是等 init.py / sync-project.py 执行时才报错。
 case "$PLATFORM" in
-    opencode|codex)
+    opencode|codex|zcode)
         if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-yaml.py" "$PLATFORM"; then
             echo "安装中止：缺少 pyyaml。请先执行 pip install pyyaml（系统 Python 权限受限时可用 pip install --user pyyaml），再重试。"
             exit 1

--- a/tools/init.py
+++ b/tools/init.py
@@ -2,7 +2,7 @@
 """
 awesome-novel-skill 项目初始化工具
 
-用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix|codex>]
+用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix|codex|zcode>]
 
 平台缺省：--platform > NOVEL_PLATFORM > SKILL_HOME 路径识别 > claude。
 
@@ -25,6 +25,7 @@ from platforms import (
     deploy_codex_agents,
     deploy_codex_skills,
     deploy_reasonix_skills,
+    deploy_zcode_skills,
     ensure_yaml,
     rewrite_refs,
     resolve_skill_home,
@@ -103,7 +104,7 @@ def main():
         a = args[i]
         if a == "--platform":
             if i + 1 >= len(args) or args[i + 1].startswith("--"):
-                print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex）")
+                print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode）")
                 sys.exit(1)
             platform_override = args[i + 1]
             i += 2
@@ -158,15 +159,17 @@ def main():
     # Step 2: 创建骨架
     create_skeleton(project_path, platform)
 
-    # Step 3: 部署 agent 定义（codex 为 TOML 转换产物，reasonix agents 即 skills）
+    # Step 3: 部署 agent 定义（codex 为 TOML 转换产物，reasonix/zcode agents 即 skills）
     if platform.key == "codex":
         deploy_codex_agents(project_path, SKILL_HOME, platform)
     else:
         deploy_agents(project_path, platform)
 
-    # Step 3.5: 部署平台 skills（reasonix 生成 11 个 SKILL.md；codex 只部署独立工具）
+    # Step 3.5: 部署平台 skills（reasonix/zcode 生成 11 个 SKILL.md；codex 只部署独立工具）
     if platform.key == "reasonix":
         deploy_reasonix_skills(project_path, SKILL_HOME, platform)
+    elif platform.key == "zcode":
+        deploy_zcode_skills(project_path, SKILL_HOME, platform)
     elif platform.key == "codex":
         deploy_codex_skills(project_path, SKILL_HOME, platform)
 
@@ -193,6 +196,8 @@ def main():
         print("在 OpenCode 中通过 @novel-agent 开始写作")
     elif platform.key == "codex":
         print("在 Codex 中打开项目目录，调用 @novel-agent 开始写作")
+    elif platform.key == "zcode":
+        print("在 ZCode 中打开项目目录，说“帮我写本小说”或调用 novel-agent skill 开始写作")
     else:
         print("在 Reasonix 中运行 `reasonix code`，然后调用 @novel-agent 开始写作")
 
@@ -221,6 +226,9 @@ def _rewrite_template_refs(text: str, platform: Platform) -> str:
     if platform.key == "reasonix":
         text = text.replace(".claude/agents/", ".reasonix/skills/")
         text = text.replace(".opencode/agents/", ".reasonix/skills/")
+    elif platform.key == "zcode":
+        text = text.replace(".claude/agents/", ".zcode/skills/")
+        text = text.replace(".opencode/agents/", ".zcode/skills/")
     elif platform.key == "codex":
         text = text.replace(".claude/agents/", ".codex/agents/")
         text = text.replace(".opencode/agents/", ".codex/agents/")
@@ -294,8 +302,8 @@ def deploy_agents(project_path: Path, platform: Platform):
         return
     agent_dir = platform.agents_dir(project_path)
     if agent_dir is None:
-        # reasonix：agents 即 skills（deploy_reasonix_skills 生成），不部署 .claude/agents
-        print("  ℹ️  reasonix 平台不部署 agent 定义（agents 即 .reasonix/skills/）")
+        # reasonix/zcode：agents 即 skills（deploy_*_skills 生成），不部署 .claude/agents
+        print(f"  ℹ️  {platform.label} 平台不部署 agent 定义（agents 即 {platform.root}/skills/）")
         return
     agent_dir.mkdir(parents=True, exist_ok=True)
     is_opencode = platform.key == "opencode"

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """平台适配层：不同 coding agent 对 agent/skill/knowledge/memory 的目录约定不同，
-init.py / sync-project.py 共用本模块完成平台检测、目录派发、引用改写与 Reasonix skill 生成。
+init.py / sync-project.py 共用本模块完成平台检测、目录派发、引用改写与 skill 生成。
 
 支持平台（扩展新平台 = 往 PLATFORMS 加一行 + 处理 agents=None 语义）：
   - claude   → .claude/   agents=agents, knowledge, memory
   - opencode → .opencode/ agents=agents, knowledge, memory
   - reasonix → .reasonix/ agents=None（agents 即 skills）, skills=skills, knowledge, memory
   - codex    → .codex/    agents=agents（TOML 转换产物）, skills=skills, knowledge, memory
+  - zcode    → .zcode/    agents=None（agents 即 skills，ZCode 无项目级 agents 目录）,
+                          skills=skills, knowledge, memory
 
 模块名用 platforms（复数）是刻意避开标准库 platform（单数）同名冲突。
 """
@@ -58,6 +60,8 @@ PLATFORMS = {
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=("reasonix",)),
     "codex":    Platform("codex", "Codex", ".codex", agents="agents",
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=(".codex",)),
+    "zcode":    Platform("zcode", "ZCode", ".zcode", agents=None,
+                         skills="skills", knowledge="knowledge", memory="memory", detect_keywords=(".zcode",)),
 }
 
 
@@ -263,6 +267,136 @@ def deploy_reasonix_skills(project: Path, skill_home: Path, platform: Platform) 
         sf = skills_dir / f"{skill_name}.md"
         if sf.exists():
             body = _convert_inline_skill(sf.read_text(encoding="utf-8"), skill_name)
+            body = rewrite_refs(body, platform)
+            skill_dir = target / skill_name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------
+# ZCode skill 生成（agents + skills 源 → .zcode/skills/<name>/SKILL.md）
+# ---------------------------------------------------------------
+
+def _convert_to_zcode(text: str, inline_sops=None) -> str:
+    """Claude Code agent frontmatter → ZCode skill frontmatter。
+
+    ZCode 与 Claude Code 约定同源（目录 + SKILL.md，工具名一致），无项目级
+    agents 目录——agents 即 skills。转换要点：
+    - frontmatter: 保留 name/description，tools → allowed-tools（裸名原样，
+      与 ZCode 工具名一致；Agent 丢弃，子 agent 无调度权，与 reasonix 同规则；
+      ZCode skill 无 runAs 字段，subagent/inline 由调用方式区分）
+    - body: agent 身份段 + 内联的专属 SOP 全文
+    - novel-agent（入口调度者）追加 ZCode 调度适配段；其余为 subagent
+    """
+    data, body = split_frontmatter(text)    # 单源解析（review #38：坏 split 已弃用）
+    if not data:
+        return text
+
+    name = str(data.get("name", "unknown")).strip()
+    desc = str(data.get("description", "") or "").strip().replace('"', "'")
+    tools_raw = str(data.get("tools", "") or "")
+    allowed = []
+    for t in tools_raw.split(","):
+        t = t.strip()
+        if not t or t == "Agent":
+            continue
+        if t not in allowed:
+            allowed.append(t)
+
+    fm = (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: \"{desc}\"\n"
+        f"allowed-tools: {', '.join(allowed)}\n"
+        f"---\n"
+    )
+
+    agent_body = body.strip()
+    if name == "novel-agent":
+        agent_body += (
+            "\n\n## ZCode 调度适配（本环境子 agent 即 skill）\n"
+            "在 ZCode 环境调度子 agent 用 `Agent` 工具：\n"
+            "- 子 agent 名即 `.zcode/skills/` 下的 skill 名（writer / volume-planner / "
+            "chapter-planner / prompt-crafter / anti-ai / reader / updater / style-distiller）\n"
+            "- 用 Agent 工具按子 agent 名 spawn，把 order 文件内容作为它的任务输入\n"
+            "- 子 agent 是隔离上下文，只读 order 与指定文件；order 文件协议（status: DONE）不变\n"
+            "- 一次只调度一个任务，等 DONE 后再调度下一个；禁止把 novel-agent 本身作为子 agent 调度\n"
+        )
+    sop_sections = []
+    for sop in (inline_sops or []):
+        if sop and sop.exists():
+            sop_sections.append(
+                f"\n---\n\n## 执行 SOP：{sop.name}\n\n{sop.read_text(encoding='utf-8').strip()}"
+            )
+    return fm + "\n" + agent_body + "\n".join(sop_sections)
+
+
+def _convert_zcode_inline_skill(text: str, name: str) -> str:
+    """纯正文 SOP → ZCode inline skill（无 SOP 依赖的独立交互工具）。"""
+    desc = ""
+    for ln in text.split("\n"):
+        if ln.strip().startswith("# ") and not ln.strip().startswith("## "):
+            desc = ln.strip().lstrip("# ").strip()
+            break
+    fm = (
+        f"---\n"
+        f"name: {name}\n"
+        f"description: \"{desc or name}（由 awesome-novel 自动生成的 ZCode skill）\"\n"
+        f"---\n"
+    )
+    return fm + "\n" + text.strip()
+
+
+def deploy_zcode_skills(project: Path, skill_home: Path, platform: Platform) -> None:
+    """生成 <project>/<platform.root>/skills/<name>/SKILL.md（11 个），引用改写为平台路径。
+
+    仅 zcode 平台调用（agents=None）。ZCode 无项目级 agents 目录，agents 即 skills，
+    产物与 reasonix 同构（9 个 agent + memory-recording/roleplay-sandbox 独立工具）。
+    """
+    if platform.key != "zcode":
+        return
+    agents_dir = skill_home / "agents"
+    skills_dir = skill_home / "skills"
+    target = platform.skills_dir(project)
+    if target is None:
+        return
+    target.mkdir(parents=True, exist_ok=True)
+
+    exec_agents = {
+        "writer": ["writing-execution"],
+        "volume-planner": ["volume-arc", "volume-direction", "volume-writing"],
+        "chapter-planner": ["chapter-reference", "chapter-outline", "chapter-verify"],
+        "prompt-crafter": ["prompt-crafting", "prompt-audit"],
+        "anti-ai": ["anti-ai"],
+        "reader": ["reader-review"],
+        "updater": ["updater-archive", "updater-setting", "updater-rollback"],
+        "style-distiller": ["style-distill"],
+    }
+    for agent_name, sops in exec_agents.items():
+        agent_file = agents_dir / f"{agent_name}.md"
+        if not agent_file.exists():
+            continue
+        sop_files = [skills_dir / f"{s}.md" for s in sops]
+        body = _convert_to_zcode(agent_file.read_text(encoding="utf-8"),
+                                 inline_sops=sop_files)
+        body = rewrite_refs(body, platform)
+        skill_dir = target / agent_name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+    novel_file = agents_dir / "novel-agent.md"
+    if novel_file.exists():
+        body = _convert_to_zcode(novel_file.read_text(encoding="utf-8"),
+                                 inline_sops=[skills_dir / "novel-dispatch.md"])
+        body = rewrite_refs(body, platform)
+        skill_dir = target / "novel-agent"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+
+    for skill_name in ("memory-recording", "roleplay-sandbox"):
+        sf = skills_dir / f"{skill_name}.md"
+        if sf.exists():
+            body = _convert_zcode_inline_skill(sf.read_text(encoding="utf-8"), skill_name)
             body = rewrite_refs(body, platform)
             skill_dir = target / skill_name
             skill_dir.mkdir(parents=True, exist_ok=True)

--- a/tools/sync-project.py
+++ b/tools/sync-project.py
@@ -36,6 +36,7 @@ from platforms import (
     detect_platform,
     deploy_codex_skills,
     deploy_reasonix_skills,
+    deploy_zcode_skills,
     ensure_yaml,
     resolve_skill_home,
     rewrite_refs,
@@ -71,7 +72,7 @@ def main():
         if idx + 1 < len(sys.argv) and not sys.argv[idx + 1].startswith("--"):
             platform_override = sys.argv[idx + 1]
         else:
-            print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex）")
+            print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode）")
             sys.exit(1)
     platform_override = platform_override or os.environ.get("NOVEL_PLATFORM")
     try:
@@ -217,7 +218,7 @@ def check_freshness(project: Path, platform: Platform):
         sys.exit(0)
     else:
         changes = find_changes(project, platform)
-        if not changes and platform.key in ("reasonix", "codex"):
+        if not changes and platform.key in ("reasonix", "codex", "zcode"):
             print("有更新可用（源文件变化，平台派生产物由同步时重新生成）。")
         elif not changes:
             # 指纹含风格资产（writing-style.md + style-profiles/**，line 143-149）而 find_changes 只扫
@@ -238,7 +239,7 @@ def check_freshness(project: Path, platform: Platform):
 
 
 def find_changes(project: Path, platform: Platform) -> list[str]:
-    """返回与源不同的文件列表（相对路径）。reasonix 的 skills 是派生产物，不枚举。"""
+    """返回与源不同的文件列表（相对路径）。reasonix/zcode 的 skills 是派生产物，不枚举。"""
     changed = []
     targets = {
         "agents": platform.agents_dir(project),
@@ -255,7 +256,7 @@ def find_changes(project: Path, platform: Platform) -> list[str]:
         src_dir = src_dirs[name]
         if dst_base is None or not src_dir.exists():
             continue
-        if platform.key == "reasonix" and name == "skills":
+        if platform.key in ("reasonix", "zcode") and name == "skills":
             continue  # 派生产物靠源指纹检测，同步时重新生成
         if platform.key == "codex" and name in ("agents", "skills"):
             continue  # TOML/SKILL.md 是派生产物，靠源指纹检测，同步时重新生成
@@ -321,7 +322,7 @@ def sync_agents(project_path: Path, platform: Platform) -> int:
         return 0
     target = platform.agents_dir(project_path)
     if target is None:
-        print("  [i] reasonix 平台无 agents 目录（agents 即 skills）")
+        print(f"  [i] {platform.label} 平台无 agents 目录（agents 即 skills）")
         return 0
     target.mkdir(parents=True, exist_ok=True)
     if platform.key == "opencode":
@@ -366,6 +367,11 @@ def sync_skills(project_path: Path, platform: Platform) -> int:
         deploy_reasonix_skills(project_path, SKILL_HOME, platform)
         n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
         print(f"  [OK] reasonix skills: {n} 个 SKILL.md 已重新生成")
+        return n
+    if platform.key == "zcode":
+        deploy_zcode_skills(project_path, SKILL_HOME, platform)
+        n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
+        print(f"  [OK] zcode skills: {n} 个 SKILL.md 已重新生成")
         return n
     if platform.key == "codex":
         deploy_codex_skills(project_path, SKILL_HOME, platform)

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -53,10 +53,13 @@ def test_detect():
     check("override=reasonix", p.detect_platform(Path("d:/x"), "reasonix").key == "reasonix")
     check("override=opencode", p.detect_platform(Path("d:/x"), "opencode").key == "opencode")
     check("override=claude", p.detect_platform(Path("d:/x"), "claude").key == "claude")
+    check("override=zcode", p.detect_platform(Path("d:/x"), "zcode").key == "zcode")
     check("path reasonix",
           p.detect_platform(Path("d:/proj/.reasonix/skills/awesome-novel")).key == "reasonix")
     check("path opencode",
           p.detect_platform(Path("d:/proj/.config/opencode/skills/awesome-novel")).key == "opencode")
+    check("path zcode",
+          p.detect_platform(Path("d:/proj/.zcode/skills/awesome-novel")).key == "zcode")
     check("default claude",
           p.detect_platform(Path("d:/code/awesome-novel-skill")).key == "claude")
 
@@ -74,6 +77,10 @@ def test_rewrite():
     check("codex 改写两处",
           out == "先 Read `.codex/knowledge/anti-ai.md` 和 `.codex/memory/volume-memory.md`",
           out)
+    out = p.rewrite_refs(text, p.PLATFORMS["zcode"])
+    check("zcode 改写两处",
+          out == "先 Read `.zcode/knowledge/anti-ai.md` 和 `.zcode/memory/volume-memory.md`",
+          out)
 
 
 def test_config():
@@ -88,10 +95,15 @@ def test_config():
           p.PLATFORMS["codex"].agents_dir(Path("P")) == Path("P") / ".codex" / "agents")
     check("codex skills 路径",
           p.PLATFORMS["codex"].skills_dir(Path("P")) == Path("P") / ".codex" / "skills")
+    check("zcode agents=None", p.PLATFORMS["zcode"].agents_dir(Path("P")) is None)
+    check("zcode skills 路径",
+          p.PLATFORMS["zcode"].skills_dir(Path("P")) == Path("P") / ".zcode" / "skills")
     check("unknown key 抛错", _raises(p.platform_from_key, "bad-key"))
     check("检测优先显式覆盖", p.detect_platform(Path("d:/x/.reasonix/skills"), "claude").key == "claude")
     check("检测 codex 路径",
           p.detect_platform(Path("d:/x/.codex/skills/awesome-novel")).key == "codex")
+    check("检测 zcode 路径",
+          p.detect_platform(Path("d:/x/.zcode/skills/awesome-novel")).key == "zcode")
     check("检测 claude 路径含 codex 子串回落 claude",
           p.detect_platform(Path("/Users/codex-dev/.claude/skills/awesome-novel")).key == "claude")
 
@@ -115,6 +127,8 @@ def test_yaml_precheck():
               _raises_system_exit(p.ensure_yaml, p.PLATFORMS["opencode"]))
         check("缺 yaml 时 reasonix 报错",
               _raises_system_exit(p.ensure_yaml, p.PLATFORMS["reasonix"]))
+        check("缺 yaml 时 zcode 报错",
+              _raises_system_exit(p.ensure_yaml, p.PLATFORMS["zcode"]))
     finally:
         builtins.__import__ = real_import
 
@@ -179,6 +193,7 @@ def test_init_layout():
         "opencode": (["agents", "knowledge", "memory"], [".claude", ".reasonix"]),
         "reasonix": (["skills", "knowledge", "memory"], [".claude"]),
         "codex":    (["agents", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
+        "zcode":    (["skills", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
     }
     for key, (subs, absents) in expect_map.items():
         with tempfile.TemporaryDirectory() as td:
@@ -215,6 +230,42 @@ def test_init_layout():
         cl = (tmp / "CLAUDE.md").read_text(encoding="utf-8")
         check("reasonix CLAUDE.md 无 .claude/agents",
               ".claude/agents" not in cl and ".reasonix/skills/" in cl, cl[:200])
+
+    # zcode 11 个 skill（与 reasonix 同构：agents 即 skills）
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "zcode")
+        names = ["novel-agent", "writer", "volume-planner", "chapter-planner",
+                 "prompt-crafter", "anti-ai", "reader", "updater", "style-distiller",
+                 "memory-recording", "roleplay-sandbox"]  # 与 deploy_zcode_skills 的 11 个 skill 名对应（spec 契约）
+        for n in names:
+            check(f"zcode skill {n}", (tmp / ".zcode/skills" / n / "SKILL.md").exists())
+        w = (tmp / ".zcode/skills/writer/SKILL.md").read_text(encoding="utf-8")
+        check("zcode writer frontmatter",
+              "name: writer" in w and "allowed-tools: Read, Write" in w
+              and "Agent" not in w.split("---", 2)[1], w.split("---", 2)[1][:200])
+        check("zcode writer 引用改写",
+              ".zcode/knowledge/" in w and ".claude/knowledge/" not in w)
+        nv = (tmp / ".zcode/skills/novel-agent/SKILL.md").read_text(encoding="utf-8")
+        check("zcode novel-agent 调度适配",
+              "Agent" in nv and ".zcode/skills/" in nv and "ZCode 调度适配" in nv)
+        check("zcode novel-agent 无 .claude 残留", ".claude" not in nv)
+        all_skills = "".join(
+            f.read_text(encoding="utf-8") for f in sorted(
+                (tmp / ".zcode/skills").rglob("SKILL.md"))
+        )
+        check("zcode 全部 skill 无 .claude 残留", ".claude" not in all_skills)
+
+    # zcode AGENTS.md / CLAUDE.md 模板改写
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "zcode")
+        ag = (tmp / "AGENTS.md").read_text(encoding="utf-8")
+        check("zcode AGENTS.md 指向 .zcode/skills",
+              ".opencode/agents" not in ag and ".zcode/skills/" in ag, ag[:200])
+        cl = (tmp / "CLAUDE.md").read_text(encoding="utf-8")
+        check("zcode CLAUDE.md 无 .claude/agents",
+              ".claude/agents" not in cl and ".zcode/skills/" in cl, cl[:200])
 
     # claude agents 数量
     with tempfile.TemporaryDirectory() as td:
@@ -328,6 +379,19 @@ def test_sync():
               'name = "writer"' in w and "developer_instructions" in w
               and ".codex/knowledge/" in w and ".claude/" not in w)
         check("codex sync 无 .claude", not (tmp / ".claude").exists())
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "zcode")
+        r = run([sys.executable, str(TOOLS / "sync-project.py"), str(tmp),
+                 "--platform", "zcode"], cwd=str(tmp))
+        check("zcode sync exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
+        check("zcode sync 保持 skill", (tmp / ".zcode/skills/writer/SKILL.md").exists())
+        w = (tmp / ".zcode/skills/writer/SKILL.md").read_text(encoding="utf-8")
+        check("zcode sync 保持 frontmatter 格式",
+              "allowed-tools:" in w and "\ntools:" not in w.split("---", 2)[1]
+              and ".zcode/knowledge/" in w and ".claude/" not in w)
+        check("zcode sync 无 .claude", not (tmp / ".claude").exists())
 
     # --check：无指纹首次 → exit 1
     with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## 背景

ZCode 的 skill 约定（目录 + `SKILL.md`）与 Claude Code 同源，天然兼容；但 ZCode **无项目级 agents 目录**（Beta 仅用户级 `~/.zcode/agents/`），因此 agents 即 skills——项目内 10 个 SKILL.md 部署到 `.zcode/skills/`，与 Reasonix 同构。

## 改动

| 文件 | 内容 |
|---|---|
| `tools/platforms.py` | zcode 平台定义（`.zcode/`，agents=None）+ `_convert_to_zcode` / `deploy_zcode_skills`（frontmatter → `allowed-tools`，novel-agent 调度适配段，引用改写） |
| `tools/init.py` / `sync-project.py` | `--platform zcode` 部署/同步、模板引用改写、提示文案 |
| `install.sh` / `install.ps1` | zcode 安装目标 `~/.zcode/skills/` + pyyaml fail-fast 门槛 |
| `README.md` / `README-en.md` / `SKILL.md` / `ARCHITECTURE.md` / `AGENTS.md` | badge、安装表、ZCode 集成章节、五平台目录树 |
| `tools/test_platforms.py` | zcode 单元 + init/sync E2E 用例 |

## 验证

- `tools/test_platforms.py`：141 通过 0 失败（含 35 个 zcode 用例）
- `check-agents.py` / `check-conflicts.py` / `py_compile` / `bash -n` 全部通过
- 实测 `init.py --platform zcode`：10 个 SKILL.md 正确生成、无 `.claude` 残留、AGENTS.md/CLAUDE.md 引用改写正确