### PR TITLE
docs: 项目结构树补齐蒸馏目录（style-profiles/ + .style-versions/）

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,12 +126,15 @@ Skill 入口（主 agent 加载 SKILL.md 后）先做项目状态检测，之后
 ├── story.md              # 项目索引（元信息 + 主线拆纲）
 ├── settings/
 │   ├── world-setting.md  # 世界观
-│   ├── writing-style.md  # 写作风格
+│   ├── writing-style.md  # 写作风格（蒸馏后含量化层主卡）
 │   ├── genre-setting.md  # 题材设定
 │   ├── foreshadowing.md  # 跨卷伏笔全局台账（init 生成空台账 / updater Step 8 维护，从 chapter.md#payoff_plan 汇总）
 │   ├── timeline.md       # 时间线（归档时追加）
-│   └── character-setting/
-│       └── <id>.md       # 每角色一个
+│   ├── character-setting/
+│   │   └── <id>.md       # 每角色一个
+│   ├── style-profiles/   # 分场景风格卡（style-distiller 蒸馏产出：dialogue/fight/group-scene/…）
+│   │   └── genre-baselines/  # 题材风格基线（base/benchmark/delta）
+│   └── .style-versions/  # 蒸馏版本快照（style-distiller 蒸馏时生成）
 ├── volumes/
 │   └── volume-{N}.md     # 卷纲
 ├── chapters/

--- a/README-en.md
+++ b/README-en.md
@@ -133,11 +133,14 @@ After setup, the Agent creates your novel project in the current directory:
 ├── CLAUDE.md             # Project-level CLAUDE.md (tools whitelist)
 ├── settings/             # Setting files
 │   ├── world-setting.md  # World building
-│   ├── writing-style.md  # Writing style
+│   ├── writing-style.md  # Writing style (quantified master card after distillation)
 │   ├── genre-setting.md  # Genre configuration
 │   ├── timeline.md       # Timeline
-│   └── character-setting/ # Character profiles
-│       └── <id>.md       # One file per character
+│   ├── character-setting/ # Character profiles
+│   │   └── <id>.md       # One file per character
+│   ├── style-profiles/   # Per-scene style cards (distilled: dialogue/fight/group-scene/…)
+│   │   └── genre-baselines/  # Genre style baselines (base/benchmark/delta)
+│   └── .style-versions/  # Distillation version snapshots (created at distill time)
 ├── volumes/              # Volume outlines
 ├── chapters/             # Chapter outlines
 ├── prompts/              # Writing prompts

--- a/README.md
+++ b/README.md
@@ -167,11 +167,14 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 ├── CLAUDE.md             # 项目级 CLAUDE.md（tools 白名单）
 ├── settings/             # 设定文件
 │   ├── world-setting.md  # 世界观
-│   ├── writing-style.md  # 写作风格
+│   ├── writing-style.md  # 写作风格（蒸馏后含量化层主卡）
 │   ├── genre-setting.md  # 题材设定
 │   ├── timeline.md       # 时间线
-│   └── character-setting/ # 角色档案
-│       └── <id>.md       # 每角色一个文件
+│   ├── character-setting/ # 角色档案
+│   │   └── <id>.md       # 每角色一个文件
+│   ├── style-profiles/   # 分场景风格卡（蒸馏产出：dialogue/fight/group-scene/…）
+│   │   └── genre-baselines/  # 题材风格基线（base/benchmark/delta）
+│   └── .style-versions/  # 蒸馏版本快照（style-distiller 蒸馏时生成）
 ├── volumes/              # 卷纲（情绪走向/冲突阶梯/信息差/场景卡）
 ├── chapters/             # 章纲
 ├── prompts/              # 提示词

--- a/SKILL.md
+++ b/SKILL.md
@@ -222,10 +222,13 @@ cp old/prompts/*.txt prompts/ 2>/dev/null
 ├── story.md              # ★ 项目索引
 ├── settings/
 │   ├── world-setting.md  # 世界观
-│   ├── writing-style.md  # 写作风格
+│   ├── writing-style.md  # 写作风格（蒸馏后含量化层主卡）
 │   ├── genre-setting.md  # 题材设定
-│   └── character-setting/
-│       └── <id>.md       # 每角色一个文件
+│   ├── character-setting/
+│   │   └── <id>.md       # 每角色一个文件
+│   ├── style-profiles/   # 分场景风格卡（蒸馏产出：dialogue/fight/group-scene/…）
+│   │   └── genre-baselines/  # 题材风格基线（base/benchmark/delta）
+│   └── .style-versions/  # 蒸馏版本快照（style-distiller 蒸馏时生成）
 ├── volumes/
 │   └── volume-{N}.md     # 卷纲
 ├── chapters/


### PR DESCRIPTION
## 背景

#93（style-distiller 双态重构）新增了 `settings/style-profiles/`（分场景风格卡 + genre-baselines 题材基线）与 `settings/.style-versions/`（蒸馏版本快照），但四处项目结构树未同步，读者在 README 里看不到蒸馏目录。

## 改动

| 文件 | 内容 |
|---|---|
| `README.md` / `README-en.md` / `ARCHITECTURE.md` / `SKILL.md` | 项目结构树 `settings/` 段补齐 `style-profiles/`（含 `genre-baselines/`）与 `.style-versions/`（标注蒸馏时生成），`character-setting/` 改非末项分支 |

纯文档补漏，无代码变更。