### PR TITLE
docs: 项目结构树补 novel-samples/ 蒸馏样本目录 + README-en 旧数字修正

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,6 +142,7 @@ Skill 入口（主 agent 加载 SKILL.md 后）先做项目状态检测，之后
 ├── prompts/
 │   └── vol-{N}-ch-{M}-prompt.md  # 6 元素提示词
 ├── sandbox/              # 推演沙盘记录（可选，roleplay-sandbox 产出）
+├── novel-samples/        # 文风蒸馏样本（作者把待学文风的文章放这里，style-distiller 专用）
 ├── archives/
 │   ├── *.draft.md        # 草稿（writer 输出，历史留档）
 │   ├── *.anti-ai.md      # 去 AI 味后版本（历史留档）

--- a/README-en.md
+++ b/README-en.md
@@ -145,18 +145,19 @@ After setup, the Agent creates your novel project in the current directory:
 ├── chapters/             # Chapter outlines
 ├── prompts/              # Writing prompts
 ├── archives/             # Finalized prose
+├── novel-samples/        # Style distillation samples (put articles you want to learn from here)
 ├── .agent/               # Agent progress + task communication
 │   ├── status.md         # Progress marker (phase/volume/chapter)
 │   └── task/             # Order files for sub-agent dispatch
 ├── .claude/              # Claude Code: agent definitions + knowledge + memory
-    ├── agents/           # 7 agent definitions (deployed at init)
+    ├── agents/           # 9 agent definitions (deployed at init)
     ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
     └── memory/           # Dynamic writing memory (feedback per phase)
         ├── volume-memory.md
         ├── chapter-memory.md
         ├── prompt-memory.md
         └── writing-memory.md
-├── .codex/               # Codex: 8 custom agents (TOML) + knowledge + memory
+├── .codex/               # Codex: 9 custom agents (TOML) + knowledge + memory
     ├── agents/           # Custom agent definitions (deployed at init)
     ├── skills/           # Standalone tools (memory-recording, roleplay-sandbox)
     ├── knowledge/        # Format specs, anti-AI rules, style profile, permanent memory
@@ -181,7 +182,7 @@ After setup, Agent helps plan the overall story structure:
 
 ### Chapter Writing Loop (Multi-Agent)
 
-7 agents collaborate — novel-agent (the director) dispatches sub-agents based on progress. You review and decide:
+9 agents collaborate — novel-agent (the director) dispatches sub-agents based on progress. You review and decide:
 
 | Step | Responsible Agent | What Happens |
 |------|-----------------|--------------|
@@ -271,7 +272,7 @@ Open the target directory in Codex and type `/use awesome-novel` (or say "帮我
 python ~/.codex/skills/awesome-novel/tools/init.py <novel-project-path> --genre <number> --platform codex
 ```
 
-The 8 custom agents are deployed as Codex TOML files (`.codex/agents/*.toml`, with `name` / `description` / `developer_instructions`), standalone tools as `.codex/skills/<name>/SKILL.md`, and anti-AI rules, style preferences, format specs, and writing memory land in `.codex/knowledge/` / `.codex/memory/`.
+The 9 custom agents are deployed as Codex TOML files (`.codex/agents/*.toml`, with `name` / `description` / `developer_instructions`), standalone tools as `.codex/skills/<name>/SKILL.md`, and anti-AI rules, style preferences, format specs, and writing memory land in `.codex/knowledge/` / `.codex/memory/`.
 
 ### Start writing
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 ├── chapters/             # 章纲
 ├── prompts/              # 提示词
 ├── sandbox/              # 剧情推演记录（可选，作者卡剧情时调用）
+├── novel-samples/        # 文风蒸馏样本（把想学文风的文章放这里，style-distiller 专用）
 ├── archives/             # 正文（定稿）
 ├── .agent/               # Agent 进度 + 任务通信
 │   ├── status.md         # 进度标记（phase/volume/chapter）

--- a/SKILL.md
+++ b/SKILL.md
@@ -237,6 +237,7 @@ cp old/prompts/*.txt prompts/ 2>/dev/null
 │   └── vol-{N}-ch-{M}-prompt.md  # 提示词
 ├── sandbox/
 │   └── vol-{N}-ch-{M}/    # 剧情推演记录（可选）
+├── novel-samples/        # 文风蒸馏样本（作者把待学文风的文章放这里，style-distiller 专用）
 ├── archives/
 │   ├── *.draft.md        # 草稿
 │   └── *.md              # 定稿


### PR DESCRIPTION
## 背景

#96（novel-samples/ 蒸馏样本目录）合入时未同步项目结构树——和 #95 修复的 style-profiles 同类遗漏。

## 改动

| 文件 | 内容 |
|---|---|
| `README.md` / `ARCHITECTURE.md` / `SKILL.md` | 项目结构树补 `novel-samples/`（文风蒸馏样本，init 骨架目录） |
| `README-en.md` | 补 `novel-samples/`；顺带修正 #93/#94 遗留旧数字：树里 7→9 agents、8→9 custom agents（Codex）、正文 7→9 agents |

纯文档，无代码变更。