### PR TITLE
feat: 设定阶段完成后增加作者确认门禁

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Skill 入口（主 agent 加载 SKILL.md 后）先做项目状态检测，之后
   │     ├── archive → updater          （archive-order.md / memory-sweep-order.md）
   │     └── # 卡冻结：归档后无风格增量更新
   ├── 子 agent 完成后将 order 覆盖为 status: DONE
-  └── 检测到 order 标记 DONE → 推进下一阶段
+  └── 检测到 order 标记 DONE → 推进下一阶段（setup 例外：setting-update-order DONE 后需作者确认设定，再推进 phase）
 ```
 
 **关键规则：**

--- a/SKILL.md
+++ b/SKILL.md
@@ -106,9 +106,12 @@ python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>]
 3. novel-agent 通过 **Agent 工具调用 updater**
 4. **updater 读取 order**，写入 `settings/world-setting.md`、`settings/genre-setting.md`、`settings/character-setting/*.md` 等设定文件
 5. updater 将 order 覆盖为 `status: DONE` 并结束
-6. **novel-agent 确认 order 标记 DONE**，推进 phase → outline，进入卷纲规划
+6. **novel-agent 确认 order 标记 DONE**（只代表写入完成），展示已写入的设定摘要给作者确认：文件清单（对照 order 的 outputs 逐项列出）+ 世界观/题材/角色/文风要点，参照 `docs/tutorial.md` 3.8 完成报告样式，面向作者用日常语言，结尾话术："设定已写入 settings/。哪里不对直接说；没问题就说'可以'，我开始规划卷纲。"
+7. **作者明确确认（"可以/没问题/就这样"；或说"之前已确认过"）→ 才可推进 phase → outline**，进入卷纲规划。作者要求修改 → novel-agent 写 setting-update-order（order 内嵌修改意见）→ 调 updater → 改完重新展示确认，循环受重试/断路器约束，连续修改仍不满意 → 暂停，请作者直接给最终文案。作者回复模糊（"差不多""你看着办""都行"）→ 追问具体哪项不确定；未明确前一律视为未确认。**未确认前不得推进 phase。**（作者说"你全权写"全自动模式 → 展示摘要后视为已确认直接推进）
 
 **权限规则：** novel-agent 不得直接写 `settings/` 下的文件，设定写入必须通过 updater 的 setting-update 模式完成。
+
+**幂等约定：** phase=setup 且 setting-update-order 已 DONE（outputs 存在非空）→ 视为「已写入、待作者确认」，中断重启后直接展示摘要等确认——不新增状态字段、不重派 updater、不推进 phase；order 缺失但 outputs 已存在 → 同样直接进入展示确认。
 
 ## 自动迁移（2.x → 3.0）
 

--- a/agents/novel-agent.md
+++ b/agents/novel-agent.md
@@ -180,6 +180,16 @@ knowledge:
     ├── setup → 与作者讨论设定（世界观/题材/角色/文风…）→ 写 setting-update-order → 调 updater
     │   ├─ **讨论到文风/写作风格时 → 进入二(文风设定决策流程)**（主动给决策点，不等作者提）
     │   └─ 作者明确表示暂不讨论文风 → 跳过（templates 预置题材卡兜底，confidence=0）
+    │    ↓ setting-update-order DONE（phase 仍为 setup 即视为「已写入、待作者确认」——**只代表写入完成，
+    │      不代表 setup 完成；此处不适用"以实际文件为准推进"**）
+    │      → 展示设定摘要给作者确认：文件清单（对照 order outputs 逐项列出）+ 世界观/题材/角色/文风要点
+    │      （面向作者用日常语言，参照 docs/tutorial.md 3.8 完成报告样式）
+    │      话术："设定已写入 settings/。哪里不对直接说；没问题就说'可以'，我开始规划卷纲。"
+    │      ├── 作者说"你全权写"（全自动模式）→ 展示摘要后视为已确认直接推进
+    │      ├── 作者明确确认（"可以/没问题/就这样"；或说"之前已确认过"）→ 推进 phase→outline, step→volume-planning
+    │      ├── 作者回复模糊（"差不多""你看着办"）→ 追问具体哪项不确定；未明确前一律视为未确认（不写 order、不推进）
+    │      └── 作者要改 → 写 setting-update-order（修改意见，内嵌 content spec）→ 调 updater → 改完再次展示确认
+    │          （修改循环受 §七 断路器约束；连续修改仍不满意 → 暂停，请作者直接给最终文案或接受当前版本）
     ├── **新卷/新章开始**：进入新一卷或新一章规划前（含卷完成判定分支进入 volume-planning 时），把 `章节状态` 重置为空（volume-planning 之前的初始态），防止上一章的"全部完成"跨卷/跨章误跳
     ├── outline: step=volume-planning → **读状态：章节状态 > volume-planning？→ 已跳过该步**；
     │            否则（= 或 <）→ volume-planner 规划卷纲 → order DONE 后推进章节状态=volume-planning
@@ -256,6 +266,7 @@ knowledge:
   VERIFY:
     检查 order 的 `status` 是否为 `DONE`（子 agent 干完活了）
     规则：order 存在且 status=DONE → 完成；status=pending → 等待；order 不存在 → 子 agent 意外中断，进重试
+      （setup 例外：setting-update-order 缺失但 outputs 已存在 → 直接进入展示确认，不重派，见 SKILL.md 幂等约定）
     **设定变更任务（setting-update-order）额外校验**：DONE 后 re-Grep 源文件（卷纲/章纲）的
       `## 设定变更通知` 头，确认 updater 已消费移除；未移除 → 视为产出不完整，重新派单，
       计入 §七 重试/断路器（连续 3 次 → STOP 进人工）

--- a/skills/novel-dispatch.md
+++ b/skills/novel-dispatch.md
@@ -76,6 +76,7 @@ outputs:
 
 | 阶段 | 已完成信号 | 判断 |
 |------|-----------|------|
+| setup | `setting-update-order` DONE 且 outputs 非空 | 不推进 phase——展示设定摘要等作者确认 |
 | volume-planning | `章节状态 > volume-planning` | 成立 → 跳过 |
 | chapter-planning | `章节状态 > chapter-planning` | 成立 → 跳过 |
 | prompt-crafting | `章节状态 > prompt-crafting` | 成立 → 跳过 |


### PR DESCRIPTION
## 背景

从 0 到 1 流程中，设定（setup）阶段完成后不会停下来让作者确认：updater 写入设定、order 标 DONE 后，novel-agent 直接推进 phase → outline。对比文风画像、卷方向、章纲验收、归档等环节都有「产出后展示给作者确认」门禁，设定阶段是唯一缺失的环节（docs/tutorial.md 3.8 已有该交互示例，但 agent 指令中无强制）。

## 改动

- **SKILL.md**：设定讨论流程第 6 步拆分——order DONE 只代表写入完成，novel-agent 展示设定摘要（文件清单对照 order outputs + 世界观/题材/角色/文风要点）给作者确认；第 7 步作者明确确认（"可以/没问题/就这样"）才推进 phase → outline。模糊回复（"差不多/你看着办"）追问不放过；修改循环受断路器约束、连续修改仍不满意则暂停请作者给最终文案；solo 全自动模式豁免；补充幂等约定（phase=setup + order DONE + outputs 非空 = 待确认，中断重启直接展示，不新增状态字段）
- **agents/novel-agent.md**：THINK setup 分支追加确认门禁树形分支（四条路径：solo 豁免 / 明确确认 / 模糊追问 / 修改循环）；显式豁免「以实际文件为准推进」规则；VERIFY 补 setup 特例回声
- **skills/novel-dispatch.md**：断点续跑表加 setup 行（DONE 且 outputs 非空 → 不推进 phase，展示摘要等确认）
- **ARCHITECTURE.md**：order DONE → 推进下一阶段处括注 setup 例外

## 验证

- `python3 tools/check-agents.py` 通过
- 提示词工程师两轮检视（方案审 + 落地验收），吸收全部修正意见
- 未改动 templates/（无 setup 确认细节，不会造成新老项目不一致）；已初始化项目经 sync-project.py 同步后生效