### PR TITLE
feat: 移植 human-writing 检查脚本为 tools/check-prose.py（活人感移植 D）

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,6 +36,8 @@ jobs:
         run: python tools/check-conflicts.py
       - name: Run platform tests
         run: python tools/test_platforms.py
+      - name: Run prose checker tests
+        run: python tools/test_check_prose.py
       - name: style-distiller 验证
         run: |
           python tools/test_style_distill.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ agent 与作家对话、提问、展示、确认一律用日常大白话。铁�
 - `skills/` — 各 agent 的 SOP 指令，按 `{环节}-{动作}.md` 命名。
 - `knowledge/` — 知识库：`genre-example/` 题材档案、`anti-ai/` 反 AI 规则、`format-specs/` 格式规范、`{plot|scene|character|title}-craft/` 创作方法论。
 - `templates/` — 项目初始化模板（`settings/`、`migration/` 旧项目迁移）。
-- `tools/` — Python 工具：`init.py`（初始化）、`sync-project.py`（同步）、`platforms.py`（平台适配）、`check-agents.py` / `check-conflicts.py` / `check-version.py` / `check-python.py` / `check-yaml.py`（静态检查）、`style_render.py` / `style_verify.py` / `style_common.py`（style-distill 渲染/验收/共享）、`test_platforms.py` / `test_style_rules.py` / `test_style_distill.py`（测试）、`test_util.py`（测试共享）。
+- `tools/` — Python 工具：`init.py`（初始化）、`sync-project.py`（同步）、`platforms.py`（平台适配）、`check-agents.py` / `check-conflicts.py` / `check-version.py` / `check-python.py` / `check-yaml.py`（静态检查）、`check-prose.py`（正文 AI 味检测，独立工具非流水线环节）、`style_render.py` / `style_verify.py` / `style_common.py`（style-distill 渲染/验收/共享）、`test_platforms.py` / `test_style_rules.py` / `test_style_distill.py` / `test_check_prose.py`（测试）、`test_util.py`（测试共享）。
 - 根目录：`README.md` / `README-en.md`、`SKILL.md`、`skill.json`、`ARCHITECTURE.md`、`CONTRIBUTING.md`、`install.sh` / `install.ps1`；图片素材在 `reference/images/`。
 
 ## 构建、测试与开发命令

--- a/tools/check-prose.py
+++ b/tools/check-prose.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""检查中文正文成稿的 AI 味硬禁令与统计形态。只报警，不自动改文。
+
+移植自 human-writing skill 的 scripts/check_prose.py
+（MIT License, Copyright (c) 2026 Human Writing Skill contributors），
+按本项目 knowledge/anti-ai/common-rules.md 口径调整：
+- 冒号不检查（网文无此禁令）；
+- 破折号不做硬禁，段落内 ≥3 处时提示逐处按用法判定（common-rules.md 破折号判定）；
+- 段落按行切分（网文章节每段一行，空行仅作分隔）。
+
+用法: python3 tools/check-prose.py <稿件路径|->    （- 从标准输入读取）
+退出码: 0 = 无失败项（可有需人工判断的警告）；1 = 存在失败项；2 = 读取失败
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8")
+
+
+HARD_STOPS = (
+    "说白了",
+    "说穿了",
+    "先说结论",
+)
+
+HARD_JARGON = (
+    "赋能",
+    "抓手",
+    "商业闭环",
+    "价值闭环",
+    "能力沉淀",
+    "拉通",
+    "底层逻辑",
+    "顶层设计",
+    "认知跃迁",
+    "价值释放",
+    "能力建设",
+    "降本增效",
+    "内容矩阵",
+    "全链路",
+    "组合拳",
+    "打开想象空间",
+    "结构性机会",
+    "关键命题",
+    "深层逻辑",
+    "技术底座",
+    "公共底座",
+    "技术主权",
+    "单点风险",
+    "主脊柱",
+    "材料锚点",
+    "认知增量",
+    "迭代闭环",
+)
+
+CONTEXT_JARGON = (
+    "沉淀",
+    "颗粒度",
+    "对齐",
+    "协同",
+    "链路",
+    "生态位",
+    "心智",
+    "范式",
+    "方法论",
+    "核心变量",
+    "打法",
+    "想象空间",
+    "闭环",
+    "不丢",
+)
+
+LYRIC_WORDS = (
+    "安放",
+    "抵达",
+    "微光",
+    "褶皱",
+    "丰盈",
+    "滚烫",
+    "轻盈",
+    "赤裸",
+    "剥开",
+)
+
+ROAD_SIGNS = (
+    "更微妙的是",
+    "还有一层",
+    "只说对了一半",
+    "值得注意的是",
+    "需要指出的是",
+    "从某种意义上说",
+)
+
+ROAD_STRIP_CHARS = "。！？!? \n"
+
+DASH_OCCURRENCE = re.compile(r"——|—|–")
+
+PIVOT_PATTERNS = (
+    re.compile(r"(?:并)?不是[^。！？\n]{0,90}而是"),
+    re.compile(r"并非[^。！？\n]{0,90}而是"),
+    re.compile(r"不在于[^。！？\n]{0,90}而在于"),
+    re.compile(r"与其说[^。！？\n]{0,90}(?:不如|毋宁|倒不如)"),
+    re.compile(r"[。！？!?]\s*而是"),
+    re.compile(r"表面(?:上)?[^。！？\n]{0,90}(?:其实|实际|实则)"),
+    re.compile(r"看似[^。！？\n]{0,90}(?:其实|实际|实则)"),
+)
+
+SEMANTIC_PIVOT_PATTERNS = (
+    re.compile(r"(?:总|一直|曾|都)?以为[^！？\n]{2,60}?(?:其实|才发现|才明白|才知道|后来才)"),
+    re.compile(r"(?:总|都|一直)以为[^！？\n]{2,60}?[。，](?:可|但|其实)"),
+    re.compile(r"回头(?:看|一看)?才(?:发现|明白|知道)"),
+    re.compile(r"(?:并)?不是[^。！？\n]{1,40}，(?:更|才)?是[^，。！？\n]"),
+    re.compile(r"从来(?:都)?(?:不是|与[^。！？，\n]{1,12}无关)"),
+    re.compile(r"答案(?:是否定的|恰恰相反)|恰恰相反"),
+    re.compile(r"表面(?:上)?[^！？\n]{0,60}。[^！？\n]{0,12}(?:其实|实际|实则)"),
+    re.compile(r"看似[^！？\n]{0,60}。[^！？\n]{0,12}(?:其实|实际|实则)"),
+    re.compile(r"[^，。！？\n]{1,12}不重要，(?:重要|要紧)的是"),
+    re.compile(r"真正[^，。！？\n]{0,16}的(?:，)?是"),
+    re.compile(r"不只(?:是)?[^。！？\n]{0,90}(?:还|也)"),
+)
+
+NOMINALIZATION_PATTERNS = (
+    re.compile(r"进行(?:了|一次|一场|着)?[^。，！？\n]{0,10}(?:调整|优化|升级|分析|讨论|沟通|梳理|复盘|迭代|探索|尝试|思考|规划|布局)"),
+    re.compile(r"实现了?[^。，！？\n]{0,14}的?[^。，！？\n]{0,6}(?:提升|增长|突破|转变|跃升|落地)"),
+    re.compile(r"完成了?对[^。，！？\n]{0,16}的"),
+    re.compile(r"起到了?[^。，！？\n]{0,12}的?作用"),
+    re.compile(r"具有[^。，！？\n]{0,10}(?:意义|价值)"),
+)
+
+CONJUNCTIONS = (
+    "因为",
+    "所以",
+    "但是",
+    "然而",
+    "同时",
+    "此外",
+    "而且",
+    "并且",
+    "因此",
+    "不仅",
+)
+
+ROAD_SIGN_PATTERNS = (
+    re.compile(
+        rf"(?:^|[。！？!?]\s*){re.escape(ROAD_SIGNS[0])}[^。！？!?\n]{{0,24}}",
+        re.MULTILINE,
+    ),
+    re.compile(
+        rf"(?:^|[。！？!?]\s*){re.escape(ROAD_SIGNS[1])}(?=(?:更|原因|问题|意思|考虑|变化|逻辑|价值|作用|风险|影响|值得|很少|不容易|常被|往往))[^。！？!?\n]{{0,24}}",
+        re.MULTILINE,
+    ),
+    *(
+        re.compile(
+            rf"(?:^|[。！？!?]\s*){re.escape(phrase)}[^。！？!?\n]{{0,24}}",
+            re.MULTILINE,
+        )
+        for phrase in ROAD_SIGNS[2:]
+    ),
+)
+
+SOFT_MARKERS = (
+    "真正",
+    "本质上",
+    "更深层次",
+    "归根结底",
+    "换句话说",
+    "不可否认",
+    "核心是",
+    "关键在于",
+    "这意味着",
+)
+
+REPEATED_OPENERS = (
+    "其实",
+    "不过",
+    "当然",
+    "所以",
+    "但是",
+    "后来",
+    "当时",
+    "很多人",
+    "问题是",
+    "更重要的是",
+    "说到这里",
+)
+
+LEFT_BRANCH_PATTERNS = (
+    re.compile(r"(?:^|[。！？]\s*)在[^，。！？\n]{12,70}(?:以后|之后|之前|以前|过程中|情况下|背景下)，"),
+    re.compile(r"(?:^|[。！？]\s*)那些[^，。！？\n]{10,60}的[^，。！？\n]{2,30}[，。]"),
+    re.compile(r"(?:^|[。！？]\s*)(?:真正|最终|最后)让[^，。！？\n]{8,70}的，是"),
+)
+
+METAPHOR_FIELDS = {
+    "温度": ("降温", "升温", "冷却", "余温", "温度最高"),
+    "生死战争": ("杀死", "死因", "枪响", "开火", "战场", "引爆", "弹药"),
+    "建筑灾害": ("坍塌", "崩塌", "地基", "砖头", "支柱", "废墟"),
+    "仓储租赁": ("仓库", "库房", "租金", "取货", "入库", "库存"),
+    "道路竞赛": ("赛道", "跑道", "岔路", "十字路口", "终点线", "门票"),
+    "机器器官": ("齿轮", "引擎", "发动机", "血管", "骨架", "肌肉"),
+    "海洋航行": ("蓝海", "浪潮", "潮水", "航船", "灯塔", "彼岸"),
+}
+
+
+@dataclass
+class Paragraph:
+    position: int
+    text: str
+    han: int
+    sentences: int
+
+
+def han_count(text: str) -> int:
+    return len(re.findall(r"[\u4e00-\u9fff]", text))
+
+
+def line_number(text: str, position: int) -> int:
+    return text.count("\n", 0, position) + 1
+
+
+def excerpt(value: str, width: int = 72) -> str:
+    value = re.sub(r"\s+", " ", value).strip()
+    return value if len(value) <= width else value[: width - 1] + "…"
+
+
+def mask_non_prose(text: str) -> str:
+    """屏蔽代码、网址和机器元数据，同时保留字符位置与换行。"""
+
+    def mask(match: re.Match[str]) -> str:
+        return "".join("\n" if char == "\n" else " " for char in match.group())
+
+    patterns = (
+        re.compile(r"\A---\s*\n.*?\n---\s*(?:\n|\Z)", re.DOTALL),
+        re.compile(r"```.*?```", re.DOTALL),
+        re.compile(r"`[^`\n]*`"),
+        re.compile(r"\]\([^\n)]*\)"),
+        re.compile(r"https?://[^\s)>]+"),
+        re.compile(r"<[^>\n]+>"),
+    )
+    masked = text
+    for pattern in patterns:
+        masked = pattern.sub(mask, masked)
+    return masked
+
+
+def non_overlapping_terms(text: str, terms: tuple[str, ...]):
+    matches = []
+    occupied = []
+    for term in sorted(terms, key=len, reverse=True):
+        for match in re.finditer(re.escape(term), text):
+            start, end = match.span()
+            if any(start < old_end and end > old_start for old_start, old_end in occupied):
+                continue
+            matches.append((start, term))
+            occupied.append((start, end))
+    return sorted(matches)
+
+
+def all_matches(text: str, patterns: tuple[re.Pattern[str], ...]):
+    matches = []
+    for pattern in patterns:
+        matches.extend(pattern.finditer(text))
+    return sorted(matches, key=lambda match: match.start())
+
+
+def heavy_de_sentences(text: str):
+    """找出主干可能被多个"的"压到后面的长句。"""
+
+    matches = []
+    pattern = re.compile(r"[^。！？!?\n]+(?:[。！？!?]|$)")
+    for match in pattern.finditer(text):
+        value = match.group()
+        if han_count(value) >= 38 and value.count("的") >= 4:
+            matches.append(match)
+    return matches
+
+
+def anaphora_runs(text: str, minimum: int = 3):
+    """找出同一句里三个以上小句用同一个开头的排比。"""
+
+    matches = []
+    for sentence in re.finditer(r"[^。！？!?\n]+(?:[。！？!?]|$)", text):
+        clauses = [
+            clause.strip()
+            for clause in re.split(r"[，、；,;]", sentence.group())
+            if han_count(clause) >= 3
+        ]
+        if len(clauses) < minimum:
+            continue
+        run = 1
+        for previous, current in zip(clauses, clauses[1:]):
+            if previous[:2] == current[:2] and re.match(r"[一-鿿]{2}", current):
+                run += 1
+                if run >= minimum:
+                    matches.append(sentence)
+                    break
+            else:
+                run = 1
+    return matches
+
+
+def sentence_length_cv(text: str):
+    """句长变异系数。人写的长短句差距大，模型的句长彼此接近。"""
+
+    lengths = [
+        han_count(match.group())
+        for match in re.finditer(r"[^。！？!?\n]+[。！？!?]", text)
+        if han_count(match.group()) >= 4
+    ]
+    if len(lengths) < 12:
+        return None
+    mean = sum(lengths) / len(lengths)
+    if mean == 0:
+        return None
+    variance = sum((value - mean) ** 2 for value in lengths) / len(lengths)
+    return (variance ** 0.5) / mean, len(lengths)
+
+
+def bracket_highlights(text: str):
+    """「」括起来的短语。太密说明在批量造金句。"""
+
+    return list(re.finditer(r"[「『][^」』\n]{1,6}[」』]", text))
+
+
+def prose_paragraphs(text: str) -> list[Paragraph]:
+    """按行切分段落（网文章节每段一行，空行仅作分隔）。"""
+
+    paragraphs = []
+    position = 0
+    for line in text.splitlines():
+        start = position
+        position += len(line) + 1
+        clean = re.sub(r"[>*_`]", "", line).strip()
+        if not clean or clean.startswith(("#", "http", "![", "```")):
+            continue
+        if re.match(r"^(?:[-+*]|\d+[.、])\s", clean):
+            continue
+        count = han_count(clean)
+        if count < 4:
+            continue
+        sentences = max(1, len(re.findall(r"[。！？!?]", clean)))
+        paragraphs.append(Paragraph(start, clean, count, sentences))
+    return paragraphs
+
+
+def metaphor_cluster(text: str, distance: int = 800):
+    hits = []
+    for field, words in METAPHOR_FIELDS.items():
+        for word in words:
+            for match in re.finditer(re.escape(word), text):
+                hits.append((match.start(), field, word))
+    hits.sort()
+    for index, (start, _, _) in enumerate(hits):
+        window = [hit for hit in hits[index:] if hit[0] - start <= distance]
+        fields = {hit[1] for hit in window}
+        if len(fields) >= 3:
+            return window, fields
+    return None
+
+
+def short_streak(paragraphs: list[Paragraph], limit: int = 4):
+    streak = []
+    for paragraph in paragraphs:
+        if paragraph.han <= 24 and paragraph.sentences <= 1:
+            streak.append(paragraph)
+            if len(streak) >= limit:
+                return streak
+        else:
+            streak = []
+    return None
+
+
+def opener_counts(paragraphs: list[Paragraph]):
+    counts = collections.Counter()
+    examples = {}
+    for paragraph in paragraphs:
+        value = paragraph.text.lstrip("“‘\"（(")
+        for opener in REPEATED_OPENERS:
+            if value.startswith(opener):
+                counts[opener] += 1
+                examples.setdefault(opener, paragraph.position)
+                break
+    return counts, examples
+
+
+def read_text(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="检查中文正文成稿的 AI 味硬禁令与统计形态")
+    parser.add_argument("path", help="Markdown 或文本文件路径。使用 - 从标准输入读取")
+    args = parser.parse_args()
+
+    try:
+        text = read_text(args.path)
+    except (OSError, UnicodeError) as error:
+        print(f"无法读取稿件。{error}", file=sys.stderr)
+        return 2
+
+    prose = mask_non_prose(text)
+    total_han = han_count(prose)
+    if total_han == 0:
+        print("没有检测到汉字。", file=sys.stderr)
+        return 2
+
+    failures = []
+    warnings = []
+
+    stop_matches = non_overlapping_terms(prose, HARD_STOPS)
+    for position, phrase in stop_matches:
+        failures.append(f"硬停词，第 {line_number(text, position)} 行，{phrase}")
+
+    jargon_matches = non_overlapping_terms(prose, HARD_JARGON)
+    for position, phrase in jargon_matches:
+        failures.append(f"黑话，第 {line_number(text, position)} 行，{phrase}")
+
+    context_jargon_matches = non_overlapping_terms(prose, CONTEXT_JARGON)
+    hard_spans = [
+        (position, position + len(phrase)) for position, phrase in jargon_matches
+    ]
+    context_jargon_matches = [
+        (position, phrase)
+        for position, phrase in context_jargon_matches
+        if not any(
+            position < end and position + len(phrase) > start
+            for start, end in hard_spans
+        )
+    ]
+    if context_jargon_matches:
+        samples = "、".join(
+            dict.fromkeys(phrase for _, phrase in context_jargon_matches)
+        )
+        lines = "、".join(
+            dict.fromkeys(
+                str(line_number(text, position))
+                for position, _ in context_jargon_matches[:8]
+            )
+        )
+        warnings.append(
+            f"有 {len(context_jargon_matches)} 处词语需要结合语境判断。"
+            f"第 {lines} 行出现 {samples}。本义准确时保留，用来抬价时改写。"
+        )
+
+    road_signs = all_matches(prose, ROAD_SIGN_PATTERNS)
+    for match in road_signs:
+        failures.append(
+            f"模型路标，第 {line_number(text, match.start())} 行，"
+            f"“{excerpt(match.group().lstrip(ROAD_STRIP_CHARS))}”"
+        )
+
+    pivots = all_matches(prose, PIVOT_PATTERNS)
+    for match in pivots:
+        failures.append(
+            f"禁用翻案句，第 {line_number(text, match.start())} 行，"
+            f"“{excerpt(match.group())}”"
+        )
+
+    occupied_spans = [match.span() for match in pivots]
+    semantic_pivots = []
+    for match in all_matches(prose, SEMANTIC_PIVOT_PATTERNS):
+        if any(
+            match.start() < end and match.end() > start
+            for start, end in occupied_spans
+        ):
+            continue
+        semantic_pivots.append(match)
+        occupied_spans.append(match.span())
+    for match in semantic_pivots:
+        warnings.append(
+            f"疑似翻案腔变形，第 {line_number(text, match.start())} 行，"
+            f"“{excerpt(match.group(), 44)}”。先立误解再推翻就改成正面陈述，正常用法保留。"
+        )
+
+    anaphoras = anaphora_runs(prose)
+    for match in anaphoras[:4]:
+        warnings.append(
+            f"三连以上同构排比，第 {line_number(text, match.start())} 行，"
+            f"“{excerpt(match.group(), 44)}”。留两项，第三项换说法或删掉。"
+        )
+
+    lyric_matches = non_overlapping_terms(prose, LYRIC_WORDS)
+    if len(lyric_matches) >= 2:
+        samples = "、".join(dict.fromkeys(term for _, term in lyric_matches))
+        warnings.append(
+            f"模型偏爱的抒情词 {len(lyric_matches)} 处。{samples}。"
+            "写具体事物时保留，给抽象概念穿衣服时删掉。"
+        )
+
+    nominalizations = all_matches(prose, NOMINALIZATION_PATTERNS)
+    for match in nominalizations[:4]:
+        warnings.append(
+            f"名词化句式，第 {line_number(text, match.start())} 行，"
+            f"“{excerpt(match.group(), 36)}”。还原成直接的动词。"
+        )
+
+    conjunction_hits = non_overlapping_terms(prose, CONJUNCTIONS)
+    if total_han >= 600 and len(conjunction_hits) * 1000 / total_han > 7:
+        samples = "、".join(
+            f"{term} {count} 次"
+            for term, count in collections.Counter(
+                term for _, term in conjunction_hits
+            ).most_common(4)
+        )
+        warnings.append(
+            f"连词密度偏高，每千字 {len(conjunction_hits) * 1000 // total_han} 个。{samples}。"
+            "中文小句靠语序和事理相接，删掉一半试试。"
+        )
+
+    highlights = bracket_highlights(prose)
+    highlight_limit = max(3, total_han // 700)
+    if len(highlights) > highlight_limit:
+        samples = "、".join(dict.fromkeys(match.group() for match in highlights[:6]))
+        warnings.append(
+            f"「」括起的短语共 {len(highlights)} 处。{samples}。太密说明在批量造金句。"
+        )
+
+    cv_result = sentence_length_cv(prose)
+    if cv_result and cv_result[0] < 0.42:
+        warnings.append(
+            f"全文 {cv_result[1]} 个句子长度过于接近（变异系数 {cv_result[0]:.2f}）。"
+            "人写的段落里十个字的句子会挨着四十个字的句子，放开几句，压短几句。"
+        )
+
+    marker_matches = non_overlapping_terms(prose, SOFT_MARKERS)
+    marker_limit = max(2, total_han // 900)
+    if len(marker_matches) > marker_limit:
+        samples = "、".join(dict.fromkeys(term for _, term in marker_matches))
+        warnings.append(
+            f"洞察路标共 {len(marker_matches)} 处，当前提醒线为 {marker_limit} 处。"
+            f"重点检查 {samples}。"
+        )
+
+    left_branches = all_matches(prose, LEFT_BRANCH_PATTERNS)
+    left_limit = max(2, total_han // 1200)
+    if len(left_branches) > left_limit:
+        samples = "；".join(
+            f"第 {line_number(text, match.start())} 行“{excerpt(match.group(), 44)}”"
+            for match in left_branches[:4]
+        )
+        warnings.append(
+            f"长前置成分共 {len(left_branches)} 处，可能让主干来得太晚。{samples}"
+        )
+
+    dense_de = heavy_de_sentences(prose)
+    dense_de_limit = max(1, total_han // 1500)
+    if len(dense_de) > dense_de_limit:
+        samples = "；".join(
+            f"第 {line_number(text, match.start())} 行“{excerpt(match.group(), 44)}”"
+            for match in dense_de[:4]
+        )
+        warnings.append(
+            f"有 {len(dense_de)} 个长句包含四个以上的“的”，可能要先交代人和动作。{samples}"
+        )
+
+    paragraphs = prose_paragraphs(prose)
+
+    dash_dense_paragraphs = 0
+    for paragraph in paragraphs:
+        dash_count = len(DASH_OCCURRENCE.findall(paragraph.text))
+        if dash_count >= 3:
+            dash_dense_paragraphs += 1
+            warnings.append(
+                f"第 {line_number(text, paragraph.position)} 行段落内破折号 {dash_count} 处，"
+                "逐处按用法判定：删掉破折号及两侧内容后意思不变则删（common-rules.md 破折号判定）。"
+            )
+
+    if len(paragraphs) >= 10:
+        one_sentence = sum(paragraph.sentences <= 1 for paragraph in paragraphs)
+        ratio = one_sentence / len(paragraphs)
+        if ratio >= 0.75:
+            warnings.append(
+                f"可识别段落中有 {ratio:.0%} 只有一句话，可能形成统一的短段鼓点。"
+            )
+
+    streak = short_streak(paragraphs)
+    if streak:
+        first = streak[0]
+        warnings.append(
+            f"从第 {line_number(text, first.position)} 行起连续出现 {len(streak)} 个短促单句段，"
+            "检查是否在排队喊结论。"
+        )
+
+    counts, opener_examples = opener_counts(paragraphs)
+    repeated = [(opener, count) for opener, count in counts.items() if count >= 4]
+    if repeated:
+        details = "、".join(f"{opener} {count} 次" for opener, count in repeated)
+        first_position = min(opener_examples[opener] for opener, _ in repeated)
+        warnings.append(
+            f"段落开场重复，从第 {line_number(text, first_position)} 行附近开始。{details}。"
+        )
+
+    metaphors = metaphor_cluster(prose)
+    if metaphors:
+        window, fields = metaphors
+        samples = "、".join(dict.fromkeys(hit[2] for hit in window))
+        warnings.append(
+            f"八百字内出现 {len(fields)} 套借喻。{'、'.join(sorted(fields))}。"
+            f"例词有 {samples}。"
+        )
+
+    print(f"汉字数 {total_han}")
+    print(
+        f"翻案句 {len(pivots)}，翻案腔变形 {len(semantic_pivots)}，"
+        f"同构排比 {len(anaphoras)}，名词化 {len(nominalizations)}，"
+        f"黑话 {len(jargon_matches)}，硬停词 {len(stop_matches)}，"
+        f"模型路标 {len(road_signs)}，需辨语境词 {len(context_jargon_matches)}，"
+        f"抒情词 {len(lyric_matches)}，洞察路标 {len(marker_matches)}，"
+        f"长前置成分 {len(left_branches)}，重定语句 {len(dense_de)}，"
+        f"破折号密集段 {dash_dense_paragraphs}"
+    )
+
+    if failures:
+        print("\n需要修改")
+        for item in failures:
+            print(f"- {item}")
+
+    if warnings:
+        print("\n需要人工判断")
+        for item in warnings:
+            print(f"- {item}")
+
+    if not failures and not warnings:
+        print("\n未发现这份检查器覆盖的问题。")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_check_prose.py
+++ b/tools/test_check_prose.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""check-prose.py 规则单测（活人感移植 Task D，issue #111）。
+
+用法: python tools/test_check_prose.py
+返回码 0 = 全部通过。
+"""
+import contextlib
+import io
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_util import check, summary, exit_code, load_module
+
+CHECK_PROSE = load_module(
+    "check_prose_mod", Path(__file__).resolve().parent / "check-prose.py"
+)
+
+CLEAN_TEXT = "\n".join([
+    "陈放把借条折了两次，塞回口袋。",
+    "老板问他是不是嫌少。他说没有，手却一直按着口袋。",
+    "门外有人催货。老板起身去接电话。",
+    "他站了一会儿，又把借条掏出来放回桌上。",
+    "“日期写错了。”",
+    "老板看了一眼。日期没有错。",
+])
+
+
+def run_check(text: str):
+    """写临时文件跑 main()，返回 (退出码, stdout)。"""
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".md", delete=False, encoding="utf-8"
+    ) as f:
+        f.write(text)
+        path = f.name
+    argv_backup = sys.argv[:]
+    sys.argv = ["check-prose.py", path]
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            code = CHECK_PROSE.main()
+    finally:
+        sys.argv = argv_backup
+        Path(path).unlink(missing_ok=True)
+    return code, buf.getvalue()
+
+
+def test_pivot_hard_fail():
+    code, out = run_check("他不是生气，而是失望。他转身走了。")
+    check("翻案句判失败（退出码 1）", code == 1, code)
+    check("输出含禁用翻案句", "禁用翻案句" in out, out[:200])
+
+
+def test_semantic_pivot_warning_only():
+    code, out = run_check("你以为他赢了，其实他输了。第二天他照常上班。")
+    check("翻案腔变形仅警告（退出码 0）", code == 0, code)
+    check("输出含疑似翻案腔变形", "疑似翻案腔变形" in out, out[:200])
+
+
+def test_dash_colon_not_hard_fail():
+    code, _ = run_check("他顿了顿——没接话。他说：“走吧。”门关上了。")
+    check("单处破折号/引语冒号不判失败（网文口径）", code == 0, code)
+
+
+def test_dash_dense_warning():
+    code, out = run_check("他进门——先看左边——又看右边——最后盯着柜子。")
+    check(
+        "同段三处破折号出警告不判失败",
+        code == 0 and "破折号" in out and "需要人工判断" in out,
+        (code, out[:200]),
+    )
+
+
+def test_road_sign_fail():
+    code, out = run_check("值得注意的是，他没走。")
+    check("模型路标判失败", code == 1 and "模型路标" in out, (code, out[:200]))
+
+
+def test_uniform_sentence_cv_warning():
+    code, out = run_check("他数了一遍又数一遍。\n" * 13)
+    check("句长过于接近出警告", "长度过于接近" in out, out[:200])
+
+
+def test_clean_text_pass():
+    code, _ = run_check(CLEAN_TEXT)
+    check("干净文本退出码 0", code == 0, code)
+
+
+def test_read_error():
+    argv_backup = sys.argv[:]
+    sys.argv = ["check-prose.py", "/nonexistent/__no_such_file__.md"]
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            code = CHECK_PROSE.main()
+    finally:
+        sys.argv = argv_backup
+    check("读取失败退出码 2", code == 2, code)
+
+
+if __name__ == "__main__":
+    test_pivot_hard_fail()
+    test_semantic_pivot_warning_only()
+    test_dash_colon_not_hard_fail()
+    test_dash_dense_warning()
+    test_road_sign_fail()
+    test_uniform_sentence_cv_warning()
+    test_clean_text_pass()
+    test_read_error()
+    print(f"\n{summary()}")
+    sys.exit(exit_code())

--- a/tools/test_util.py
+++ b/tools/test_util.py
@@ -11,6 +11,7 @@ test_style_rules.py / test_style_distill.py / test_platforms.py 三个测试文�
   print(f"\n{summary()}"); sys.exit(exit_code())
 """
 import importlib.util
+import sys
 from pathlib import Path
 
 PASS = 0
@@ -37,8 +38,10 @@ def exit_code() -> int:
 
 def load_module(name: str, path) -> object:
     """按文件路径加载模块（文件名含连字符无法直接 import，如 check-agents.py）。
-    各测试文件共用的 importlib 样板（review #41：此前 ×5 复制）。"""
+    各测试文件共用的 importlib 样板（review #41：此前 ×5 复制）。
+    先注册进 sys.modules 再 exec——模块内使用 @dataclass 时需要可解析的 __module__。"""
     spec = importlib.util.spec_from_file_location(name, str(Path(path)))
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod


### PR DESCRIPTION
## 改动

四步移植计划（#111）第一步：把 human-writing skill 的确定性检查脚本搬进来，给去 AI 味管线一把机器尺子。

- 新增 `tools/check-prose.py`：移植 human-writing `scripts/check_prose.py`（MIT，保留版权声明），按本项目口径调整——冒号不检查；破折号不做硬禁（同段 ≥3 处提示逐处按 common-rules.md 破折号判定）；段落按行切分适配网文每段一行。翻案句双正则（字面+语义变形）、句长变异系数、短段鼓点、开场重复、比喻场聚集、名词化、同构排比等检测全量保留。只报警不自动改文，退出码 0/1/2。
- 新增 `tools/test_check_prose.py`：10 用例（先红后绿），覆盖翻案句判失败、变形仅警告、破折号/冒号网文口径、密集破折号警告、模型路标、句长均匀警告、干净文本通过、读取失败退出码。
- `tools/test_util.py`：`load_module` 先注册 `sys.modules` 再 exec——Python 3.9 下加载含 `@dataclass` 的模块会因 `__module__` 不可解析而崩溃。
- CI（static.yml）挂入 `test_check_prose.py`。

## 验证

- `python3 tools/test_check_prose.py` → 10 passed
- 全套：check-agents / check-conflicts / check-version 通过；test_platforms 198 通过；test_style_distill 84、test_style_rules 125 通过
- 冒烟：对 `knowledge/anti-ai/anti-ai-writing.md` 实跑，准确命中其引用的 ❌ 范例句

## 后续（另 PR）

A（living-voice 正向方法论）→ C（验收去表演化）→ B（prompt 注入稳妥版）。

Refs #111
