### PR TITLE
feat: 接入 Grok Build 平台（install/init/sync + 子代理调度）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ agent 与作家对话、提问、展示、确认一律用日常大白话。铁�
 
 ## 构建、测试与开发命令
 
-无构建步骤。Python 主体仅用标准库；pyyaml 例外：`--platform opencode|reasonix|codex|zcode|dsh` 的 agent 转换（platforms.py）与 style-distill 卡 frontmatter 解析/校验（style_common.py / style_render.py / check-agents.py）（见 `tools/requirements.txt`，CI 自动安装）：
-- `python tools/init.py <项目路径> [--genre N] [--platform claude|opencode|reasonix|codex|zcode|dsh]` — 初始化小说项目骨架
+无构建步骤。Python 主体仅用标准库；pyyaml 例外：`--platform opencode|reasonix|codex|zcode|dsh|grok` 的 agent 转换（platforms.py）与 style-distill 卡 frontmatter 解析/校验（style_common.py / style_render.py / check-agents.py）（见 `tools/requirements.txt`，CI 自动安装）：
+- `python tools/init.py <项目路径> [--genre N] [--platform claude|opencode|reasonix|codex|zcode|dsh|grok]` — 初始化小说项目骨架
 - `python tools/sync-project.py <项目路径> --check` — 检查项目是否需要同步（0=最新，1=有更新，2=无效）
 - `python tools/test_platforms.py` — 运行测试（退出码 0=通过）
 - `python tools/check-agents.py` — 校验 agent frontmatter 引用路径
@@ -87,7 +87,7 @@ CI：`.github/workflows/static.yml`，push main 时运行语法/agent/规则检�
 ## 测试指南
 
 - 无第三方测试框架；`tools/test_platforms.py` 自写断言，stdout 打印 `ok/FAIL`，非 0 退出码表示失败。
-- 测试函数以 `test_` 开头；E2E 用临时目录验证 init/sync 在 claude/opencode/reasonix/codex/zcode/dsh 六平台的输出。
+- 测试函数以 `test_` 开头；E2E 用临时目录验证 init/sync 在 claude/opencode/reasonix/codex/zcode/dsh/grok 七平台的输出。
 - 涉及 agent 定义跑 `check-agents.py`，涉及反 AI 规则跑 `check-conflicts.py`。
 - 行为变更遵循先红后绿：先加失败用例，再实现。
 
@@ -95,7 +95,7 @@ CI：`.github/workflows/static.yml`，push main 时运行语法/agent/规则检�
 
 - 提交信息遵循 Conventional Commits + 中文描述：`feat:` / `fix:` / `docs:` / `test:` / `refactor:` / `chore:`，如 `fix: sync-project --platform 值守卫防吞 --check`。
 - 发版时 `chore: bump version to vX.Y.Z`，同步更新 `VERSION` 与 `docs/releasenote-*`。
-- PR：从 main 新建分支，禁止直接改 main；单个 PR 聚焦一项改动并关联 issue；提交前至少在一种 AI 终端实测（claude/opencode/reasonix/codex/zcode/dsh）。
+- PR：从 main 新建分支，禁止直接改 main；单个 PR 聚焦一项改动并关联 issue；提交前至少在一种 AI 终端实测（claude/opencode/reasonix/codex/zcode/dsh/grok）。
 
 ## 安全与配置提示
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,6 +199,7 @@ tools/           # init.py（初始化）、sync-project.py（同步更新）
 - **Codex**：init.py 部署 9 个自定义 agent 为 `.codex/agents/*.toml`（TOML 转换产物，引用改写为 `.codex/knowledge|memory`），独立工具为 `.codex/skills/<name>/SKILL.md`；novel-agent 用 `spawn_agent` 调度子 agent
 - **ZCode**：init.py 部署 9 个 agent 为 `.zcode/skills/<name>/SKILL.md`（skill 转换产物，引用改写为 `.zcode/knowledge|memory`；ZCode 无项目级 agents 目录，agents 即 skills，与 Reasonix 同构）；novel-agent 用 `Agent` 工具按 skill 名调度子 agent
 - **dsh（DeepSeek Harness）**：init.py 部署 9 个 agent 为 `.dsh/skills/<name>/SKILL.md`（skill 转换产物，frontmatter 只保留 dsh 识别的 `name`/`description`，引用改写为 `.dsh/knowledge|memory`；dsh 无项目级 agents 目录，agents 即 skills，与 ZCode 同构）；novel-agent 用 `subagent` 工具调度子 agent（prompt 要求子 agent 先 `skill(name=...)` 加载自身指令）
+- **Grok Build**：init.py 部署 9 个自定义 agent 为 `.grok/agents/*.md`（Grok 原生发现路径，frontmatter 映射为 Grok 工具名，SOP 内联，引用改写为 `.grok/knowledge|memory`），独立工具为 `.grok/skills/<name>/SKILL.md`；novel-agent 用 `spawn_subagent` 调度子 agent（必须在主会话运行，Grok 子代理深度上限为 1）
 - **安装**：`install.sh` / `install.ps1` 将 skill 装到用户级 skills 目录
 
 ---

--- a/README-en.md
+++ b/README-en.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>Write Novels with Claude Code / OpenCode / Reasonix / Codex / ZCode / DeepSeek Harness</em>
+  <em>Write Novels with Claude Code / OpenCode / Reasonix / Codex / ZCode / DeepSeek Harness / Grok Build</em>
 </p>
 
 <p align="center">
@@ -10,6 +10,7 @@
   <a href="#codex-integration"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
   <a href="#zcode-integration"><img src="https://img.shields.io/badge/ZCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-0EA5E9?style=flat-square" alt="ZCode"></a>
   <a href="#dsh-integration"><img src="https://img.shields.io/badge/DeepSeek%20Harness-%E2%9C%93%20%E6%94%AF%E6%8C%81-1F6FEB?style=flat-square" alt="DeepSeek Harness"></a>
+  <a href="#grok-build-integration"><img src="https://img.shields.io/badge/Grok%20Build-%E2%9C%93%20%E6%94%AF%E6%8C%81-111111?style=flat-square" alt="Grok Build"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
 </p>
@@ -49,14 +50,14 @@ Let AI be your novel writing partner, from world-building to character developme
 
 ## What You Need
 
-- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, **Codex**, **ZCode** or **DeepSeek Harness (dsh)** installed
+- A computer with [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), [OpenCode](https://github.com/sglaboratory/opencode), Reasonix, **Codex**, **ZCode**, **DeepSeek Harness (dsh)** or **[Grok Build](https://docs.x.ai/build/overview)** installed
 - Python 3.9+ (the one bundled with macOS works; 3.11+ recommended)
-- pyyaml for OpenCode / Codex / ZCode / dsh (`pip install pyyaml`; use `pip install --user pyyaml` if the system Python is permission-restricted)
+- pyyaml for OpenCode / Codex / ZCode / dsh / Grok Build (`pip install pyyaml`; use `pip install --user pyyaml` if the system Python is permission-restricted)
 - About 1 minute to install
 
 ## Installation
 
-**No copy-pasting needed.** Open the AI tool you use (Claude Code / OpenCode / Codex / ZCode / DeepSeek Harness) and tell it:
+**No copy-pasting needed.** Open the AI tool you use (Claude Code / OpenCode / Codex / ZCode / DeepSeek Harness / Grok Build) and tell it:
 
 > **Install awesome-novel-agent for me**
 
@@ -69,8 +70,9 @@ The agent will download from <https://github.com/modoojunko/awesome-novel-agent>
 | Codex | `~/.codex/skills/awesome-novel/` |
 | ZCode | `~/.zcode/skills/awesome-novel/` |
 | DeepSeek Harness | `~/.dsh/skills/awesome-novel/` |
+| Grok Build | `~/.grok/skills/awesome-novel/` |
 
-You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex` / `zcode` / `dsh`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version (3.9+ required) and the pyyaml dependency (opencode / codex / zcode / dsh only), and aborts with clear messages instead of failing later when `init.py` / `sync-project.py` run.
+You're done once you see **"安装完成"** (Installation complete). To install manually, clone the repo and run `./install.sh <platform>` (`claude-code` / `opencode` / `codex` / `zcode` / `dsh` / `grok`); on Windows (PowerShell) run `install.ps1 <platform>`. `install.sh` also supports `deepseek-tui` / `hermes` / `openclaw` (non-primary platforms). The installer checks the Python version (3.9+ required) and the pyyaml dependency (opencode / codex / zcode / dsh / grok only), and aborts with clear messages instead of failing later when `init.py` / `sync-project.py` run.
 
 **Reasonix:**
 
@@ -424,6 +426,46 @@ Open the project directory in dsh and say **"帮我写本小说"** or **"帮我�
 ```
 
 Upgrade later with `python tools/sync-project.py <novel-project-path> --platform dsh`.
+
+## Grok Build Integration
+
+This skill also supports [Grok Build](https://docs.x.ai/build/overview) (SpaceXAI's coding-agent TUI). The skill convention (directory + `SKILL.md`) is compatible with Claude Code's — **natively supported**. Custom agents are deployed to `.grok/agents/*.md` (Grok's native discovery path). The skill itself is installed **user-level**, while project contents (agents/skills/knowledge/memory) are deployed **project-level** into `.grok/`.
+
+**Hard constraint:** novel-agent must run in the main session. Grok subagents cannot spawn further subagents (depth limit 1); dispatching novel-agent as a child breaks the chain.
+
+### Install
+
+Tell Grok Build "Install awesome-novel-agent for me" and it runs `./install.sh grok` (Windows: `install.ps1 grok`), installing to `~/.grok/skills/awesome-novel/`.
+
+### Initialize a project
+
+Open the target directory in Grok Build and type `/awesome-novel` (or say "help me write a novel"). You can also run:
+
+```bash
+python ~/.grok/skills/awesome-novel/tools/init.py <novel-project-path> --genre <number> --platform grok
+```
+
+The 9 custom agents are deployed as Markdown under `.grok/agents/*.md` (`name` / `description` / `tools`), standalone tools as `.grok/skills/<name>/SKILL.md`, and anti-AI rules, style preferences, format specs, and writing memory land in `.grok/knowledge/` / `.grok/memory/`.
+
+### Start writing
+
+Open the project directory in Grok Build and type `/awesome-novel` or say **"帮我写本小说"** / **"帮我继续写"**. In Grok, novel-agent dispatches sub-agents with `spawn_subagent` (`subagent_type` = the Markdown name under `.grok/agents/`, `isolation: none`); the order-file protocol is identical to the other platforms.
+
+### Project structure differences
+
+```
+.grok/
+├── agents/               # 9 custom agents (Markdown)
+│   ├── novel-agent.md
+│   ├── writer.md
+│   ├── volume-planner.md
+│   └── ...
+├── skills/               # standalone tools (memory-recording, roleplay-sandbox)
+├── knowledge/            # anti-AI rules, style preferences, permanent memory, format specs
+└── memory/               # dynamic writing memory
+```
+
+Upgrade later with `python tools/sync-project.py <novel-project-path> --platform grok`.
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <strong>awesome-novel</strong><br>
-  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix / Codex / ZCode / DeepSeek Harness</em>
+  <em>和 AI 一起写小说 —— 支持 Claude Code / OpenCode / Reasonix / Codex / ZCode / DeepSeek Harness / Grok Build</em>
 </p>
 
 <p align="center">
@@ -11,6 +11,7 @@
   <a href="#codex-集成"><img src="https://img.shields.io/badge/Codex-%E2%9C%93%20%E6%94%AF%E6%8C%81-10A37F?style=flat-square" alt="Codex"></a>
   <a href="#zcode-集成"><img src="https://img.shields.io/badge/ZCode-%E2%9C%93%20%E6%94%AF%E6%8C%81-0EA5E9?style=flat-square" alt="ZCode"></a>
   <a href="#dsh-集成"><img src="https://img.shields.io/badge/DeepSeek%20Harness-%E2%9C%93%20%E6%94%AF%E6%8C%81-1F6FEB?style=flat-square" alt="DeepSeek Harness"></a>
+  <a href="#grok-build-集成"><img src="https://img.shields.io/badge/Grok%20Build-%E2%9C%93%20%E6%94%AF%E6%8C%81-111111?style=flat-square" alt="Grok Build"></a>
   <br>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-GPL%203.0-blue?style=flat-square" alt="GPL 3.0"></a>
   <br>
@@ -70,9 +71,9 @@
 
 ## 你需要什么
 
-- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix**、**Codex**、**ZCode** 或 **DeepSeek Harness（dsh）** 的电脑
+- 安装了 [Claude Code](https://docs.anthropic.com/zh-CN/docs/claude-code/overview)、[OpenCode](https://github.com/sglaboratory/opencode)、**Reasonix**、**Codex**、**ZCode**、**DeepSeek Harness（dsh）** 或 **[Grok Build](https://docs.x.ai/build/overview)** 的电脑
 - Python 3.9+（macOS 系统自带 3.9 即可用；推荐 3.11+）
-- OpenCode / Codex / ZCode / dsh 平台还需 pyyaml（`pip install pyyaml`；系统 Python 权限受限时用 `pip install --user pyyaml`）
+- OpenCode / Codex / ZCode / dsh / Grok Build 平台还需 pyyaml（`pip install pyyaml`；系统 Python 权限受限时用 `pip install --user pyyaml`）
 - 大概 1 分钟完成安装
 
 
@@ -91,8 +92,9 @@ AI 会自动从仓库 <https://github.com/modoojunko/awesome-novel-agent> 下载
 | Codex | `~/.codex/skills/awesome-novel/` |
 | ZCode | `~/.zcode/skills/awesome-novel/` |
 | DeepSeek Harness | `~/.dsh/skills/awesome-novel/` |
+| Grok Build | `~/.grok/skills/awesome-novel/` |
 
-看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex` / `zcode` / `dsh`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh / install.ps1 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+）和 pyyaml 依赖（仅 opencode / codex / zcode / dsh），不满足会直接中止并给出升级 / 安装提示，不会等到 `init.py` / `sync-project.py` 执行时才报错。
+看到 **"安装完成"** 就可以了。想手动安装时，克隆仓库后运行 `./install.sh <平台>`（平台：`claude-code` / `opencode` / `codex` / `zcode` / `dsh` / `grok`）；Windows 用 PowerShell 时运行 `install.ps1 <平台>`。install.sh / install.ps1 同时兼容 deepseek-tui / hermes / openclaw（非主推平台）。安装脚本会先检查 Python 版本（需要 3.9+）和 pyyaml 依赖（仅 opencode / codex / zcode / dsh / grok），不满足会直接中止并给出升级 / 安装提示，不会等到 `init.py` / `sync-project.py` 执行时才报错。
 
 **Reasonix：**
 
@@ -124,6 +126,15 @@ dsh 的 skill 约定与 Claude Code 同源（目录 + `SKILL.md`），但**无�
 python ~/.dsh/skills/awesome-novel/tools/init.py <小说项目路径> --platform dsh
 ```
 
+**Grok Build：**
+
+Grok Build 的 skill 约定（目录 + `SKILL.md`）与 Claude Code 同源，**天然兼容**；自定义 agent 走项目 `.grok/agents/*.md`（Grok 原生发现路径）。skill 本体走 install.sh 用户级安装，项目内容由 `init.py --platform grok` 项目级部署到 `.grok/`：
+
+```bash
+./install.sh grok
+python ~/.grok/skills/awesome-novel/tools/init.py <小说项目路径> --platform grok
+```
+
 > **OpenCode 用户注意：** 安装路径为 `~/.config/opencode/skills/awesome-novel/`，初始化后 agent 定义部署在项目 `.opencode/agents/` 下，OpenCode 自动发现。详情见下方 [OpenCode 集成](#opencode) 说明。
 
 > **Codex 用户注意：** skill 安装到 `~/.codex/skills/awesome-novel/`，初始化后 9 个自定义 agent 以 TOML 形式部署在项目 `.codex/agents/` 下，Codex 自动发现。详情见下方 [Codex 集成](#codex-集成) 说明。
@@ -132,12 +143,14 @@ python ~/.dsh/skills/awesome-novel/tools/init.py <小说项目路径> --platform
 
 > **DeepSeek Harness 用户注意：** skill 安装到 `~/.dsh/skills/awesome-novel/`，初始化后 9 个 agent 以 SKILL.md 形式部署在项目 `.dsh/skills/` 下（dsh 无项目级 agents 目录，agents 即 skills），dsh 自动发现。详情见下方 [dsh 集成](#dsh-集成) 说明。
 
+> **Grok Build 用户注意：** skill 安装到 `~/.grok/skills/awesome-novel/`，初始化后 9 个自定义 agent 以 Markdown 形式部署在项目 `.grok/agents/` 下（Grok 原生发现），独立工具部署为 `.grok/skills/`。novel-agent 必须在主会话运行。详情见下方 [Grok Build 集成](#grok-build-集成) 说明。
+
 > **看到这个项目觉得有用？** 顺手点个 Star，这样它会出现在你的 GitHub 首页，让更多人发现。
 > {: .prompt-info }
 
 ## 开始写小说
 
-安装好本体后，在**你想放小说项目的目录**下启动 Claude Code / OpenCode / Codex / ZCode / DeepSeek Harness，输入：
+安装好本体后，在**你想放小说项目的目录**下启动 Claude Code / OpenCode / Codex / ZCode / DeepSeek Harness / Grok Build，输入：
 
 > **/awesome-novel**
 
@@ -145,7 +158,7 @@ python ~/.dsh/skills/awesome-novel/tools/init.py <小说项目路径> --platform
 
 skill 会自动检测目录状态：新目录会先和你确认，然后运行 `init.py` 在本地初始化小说工作空间（项目骨架、agent 定义、知识库、记忆文件），完成后进入写作流程。后续再进入该项目时，说 `@novel-agent` 或 **"帮我继续写"** 就能从中断处恢复。
 
-Reasonix 用户在项目目录运行 `reasonix code` 后，输入 `@novel-agent` 进入写作流程。ZCode 用户在项目目录说 **"帮我写本小说"** 或 **"帮我继续写"** 即可（ZCode 无 `@` 语法，agents 即 skills，novel-agent 由 ZCode 自动发现）。DeepSeek Harness 用户同样直接说 **"帮我写本小说"** 或 **"帮我继续写"** 即可（dsh 的 skill 由模型按 name/description 自动路由）。
+Reasonix 用户在项目目录运行 `reasonix code` 后，输入 `@novel-agent` 进入写作流程。ZCode 用户在项目目录说 **"帮我写本小说"** 或 **"帮我继续写"** 即可（ZCode 无 `@` 语法，agents 即 skills，novel-agent 由 ZCode 自动发现）。DeepSeek Harness 用户同样直接说 **"帮我写本小说"** 或 **"帮我继续写"** 即可（dsh 的 skill 由模型按 name/description 自动路由）。Grok Build 用户输入 `/awesome-novel` 或说 **"帮我写本小说"**。
 
 Agent 会引导你完成后续步骤。系统由 9 个 AI Agent 协作驱动，自动检测进度、调度任务，你只需确认方向和审阅内容。
 
@@ -199,11 +212,11 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 ├── .agent/               # Agent 进度 + 任务通信
 │   ├── status.md         # 进度标记（phase/volume/chapter）
 │   └── task/             # 子 agent 间 order 文件
-├── .opencode/            # OpenCode 用（六选一，由 init.py --platform 决定）
+├── .opencode/            # OpenCode 用（七选一，由 init.py --platform 决定）
 │   ├── agents/           # 9 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆
-├── .claude/              # Claude Code 用（六选一）
+├── .claude/              # Claude Code 用（七选一）
 │   ├── agents/           # 9 个 Agent 定义（初始化时部署）
 │   ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
 │   └── memory/           # 写作动态记忆（各环节作者反馈）
@@ -211,26 +224,31 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 │       ├── chapter-memory.md
 │       ├── prompt-memory.md
 │       └── writing-memory.md
-├── .reasonix/            # Reasonix 用（六选一）
+├── .reasonix/            # Reasonix 用（七选一）
     ├── skills/           # 11 个 SKILL.md（agents 即 skills）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
-├── .codex/               # Codex 用（六选一）
+├── .codex/               # Codex 用（七选一）
     ├── agents/           # 9 个自定义 agent（TOML，初始化时部署）
     ├── skills/           # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
-├── .zcode/               # ZCode 用（六选一）
+├── .zcode/               # ZCode 用（七选一）
     ├── skills/           # 11 个 SKILL.md（agents 即 skills，初始化时部署）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
-└── .dsh/                 # DeepSeek Harness 用（六选一）
+├── .dsh/                 # DeepSeek Harness 用（七选一）
     ├── skills/           # 11 个 SKILL.md（agents 即 skills，初始化时部署）
+    ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
+    └── memory/           # 写作动态记忆
+└── .grok/                # Grok Build 用（七选一）
+    ├── agents/           # 9 个自定义 agent（Markdown，初始化时部署）
+    ├── skills/           # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/        # 格式规范、反 AI 规则、文风偏好、永久记忆
     └── memory/           # 写作动态记忆
 ```
 
-这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` / `.dsh/` 不会同时存在。
+这些全是纯文本 Markdown 文件，你可以直接用编辑器打开看或手动改。实际项目只生成一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` / `.dsh/` / `.grok/` 不会同时存在。
 
 ### 规划故事骨架
 
@@ -304,7 +322,7 @@ novel-agent 只负责调度和验证，不直接写内容。子 agent 各司其�
 
 **Q: 我不会编程，能装吗？**
 
-能。打开你的 AI 工具，对它说"帮我安装 awesome-novel-agent，仓库在 https://github.com/modoojunko/awesome-novel-agent"，AI 会自己运行安装脚本，全程不用复制粘贴命令。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix、Codex 或 ZCode。
+能。打开你的 AI 工具，对它说"帮我安装 awesome-novel-agent，仓库在 https://github.com/modoojunko/awesome-novel-agent"，AI 会自己运行安装脚本，全程不用复制粘贴命令。唯一的前提是你的电脑上已经装好了 Claude Code、OpenCode、Reasonix、Codex、ZCode、DeepSeek Harness 或 Grok Build。
 
 **Q: 我升级了技能，之前写的小说项目怎么迁移到新格式？**
 
@@ -626,3 +644,43 @@ python ~/.dsh/skills/awesome-novel/tools/init.py <小说项目路径> --genre <�
 ```
 
 升级时用 `python tools/sync-project.py <小说项目路径> --platform dsh` 同步最新框架。
+
+## Grok Build 集成
+
+本 skill 也支持 [Grok Build](https://docs.x.ai/build/overview)（SpaceXAI 的编码 agent TUI）。skill 约定（目录 + `SKILL.md`）与 Claude Code 同源，**天然兼容**；自定义 agent 部署到项目 `.grok/agents/*.md`（Grok 原生发现路径）。skill 本体**用户级安装**，小说项目内的 agents/skills/knowledge/memory 全部**项目级部署**在 `.grok/`。
+
+**关键约束：** novel-agent 必须在主会话运行。Grok 的子代理不能再派子代理（深度上限 1），把 novel-agent 当 subagent 会让调度链断裂。
+
+### 安装
+
+在 Grok Build 里输入 **"帮我安装 awesome-novel-agent"**，它会自动运行 `./install.sh grok`（Windows 用 `install.ps1 grok`），安装到 `~/.grok/skills/awesome-novel/`。
+
+### 初始化项目
+
+在 Grok Build 中打开目标目录，输入 `/awesome-novel`（或说"帮我写本小说"），skill 会自动初始化；也可手动运行：
+
+```bash
+python ~/.grok/skills/awesome-novel/tools/init.py <小说项目路径> --genre <编号> --platform grok
+```
+
+初始化后 9 个自定义 agent 以 Markdown 部署到项目 `.grok/agents/*.md`（`name` / `description` / `tools`），独立交互工具（memory-recording、roleplay-sandbox）部署为 `.grok/skills/<name>/SKILL.md`，反 AI 规则、文风偏好、格式规范与写作记忆分别落在 `.grok/knowledge/`、`.grok/memory/`。
+
+### 开始写作
+
+初始化完成后，在 Grok Build 中打开项目目录，输入 `/awesome-novel` 或说 **"帮我写本小说"** / **"帮我继续写"** 进入写作循环。Grok 环境里 novel-agent 用 `spawn_subagent` 调度子 agent（`subagent_type` = `.grok/agents/*.md` 的 name，`isolation: none`），order 文件协议与其余平台一致。
+
+### 项目结构差异
+
+```
+.grok/
+├── agents/               # 9 个自定义 agent（Markdown）
+│   ├── novel-agent.md
+│   ├── writer.md
+│   ├── volume-planner.md
+│   └── ...
+├── skills/               # 独立交互工具（memory-recording、roleplay-sandbox）
+├── knowledge/            # 反 AI 规则、文风偏好、永久记忆、格式规范
+└── memory/               # 写作动态记忆
+```
+
+升级时用 `python tools/sync-project.py <小说项目路径> --platform grok` 同步最新框架。

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 
 和 AI 一起写小说。本 skill 负责项目状态检测、新项目初始化、旧版项目自动迁移，完成后将控制权交给 novel-agent。
 
-**唤起方式：** 用户在项目目录输入 `/awesome-novel`（Claude Code / OpenCode 直接输入；Codex 输入 `/use awesome-novel`；或说"帮我写本小说"）即进入下方检测流程。新目录会先询问作者，确认后运行 `init.py` 在本地初始化小说工作空间。
+**唤起方式：** 用户在项目目录输入 `/awesome-novel`（Claude Code / OpenCode / Grok Build 直接输入；Codex 输入 `/use awesome-novel`；或说"帮我写本小说"）即进入下方检测流程。新目录会先询问作者，确认后运行 `init.py` 在本地初始化小说工作空间。
 
 ## OpenCode 集成说明
 
@@ -43,6 +43,15 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 
 **调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ 用 `subagent` 工具调度子 agent（prompt 中要求子 agent 先调用 `skill(name="<子agent名>")` 加载自身指令；子 agent 名 = `.dsh/skills/` 下的 skill 名）→ 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。order 文件协议与其余平台完全一致。
 
+## Grok Build 集成说明
+
+本 skill 也支持 [Grok Build](https://docs.x.ai/build/overview)（SpaceXAI 的编码 agent TUI）。skill 本体**用户级安装**到 `~/.grok/skills/awesome-novel/`；`init.py --platform grok` 初始化小说项目时，把 9 个自定义 agent 部署为项目级 `.grok/agents/*.md`（Grok 原生 agent 发现路径，含 `name`/`description`/`tools`）：
+- novel-agent — 总指挥（必须在主会话运行；Grok 子代理深度上限为 1，禁止把 novel-agent 当 subagent 调度）
+- writer、volume-planner、chapter-planner 等 — 子 agent（由 novel-agent 用 `spawn_subagent` 按 `subagent_type` 调度）
+- **独立工具** — `memory-recording`、`roleplay-sandbox` 部署为 `.grok/skills/<name>/SKILL.md`
+
+**调度机制：** novel-agent 写 order 文件到 `.agent/task/`（`status: pending`）→ 用 `spawn_subagent` 调度子 agent（`subagent_type` = `.grok/agents/*.md` 的 name，`isolation: none`）→ 子 agent 读取 order 执行 → 完成后将 order 覆盖为 `status: DONE` 后退回。order 文件协议与其余平台完全一致。
+
 ## 检测流程 — 严格按此执行，禁止跳过
 
 ```
@@ -68,7 +77,7 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 - 确认后必须运行 `init.py`，禁止手动创建目录结构替代
 - **禁止在 skill 安装目录（含 `skills/awesome-novel` 路径）内运行 `init.py`** — 此目录是技能仓库，不是小说项目
 - 如果当前目录是 skill 安装目录，应提示作者切换到目标目录后再执行
-- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/`；ZCode → `.zcode/skills/`；dsh → `.dsh/skills/`），方可进入 novel-agent
+- `init.py` 执行完毕后，确认 `.agent/status.md` 与平台部署目录已生成（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix → `.reasonix/skills/`；Codex → `.codex/agents/`；ZCode → `.zcode/skills/`；dsh → `.dsh/skills/`；Grok Build → `.grok/agents/`），方可进入 novel-agent
 - 如果 `init.py` 报错，必须先修复问题重新执行，不允许绕过
 
 ## 初始化 — 先询问，确认后执行，不可跳过
@@ -78,15 +87,15 @@ description: 和 AI 协作写小说的工作流系统。9 个 agent 协作完成
 python <本 skill 安装目录>/tools/init.py [project-path] [--genre <编号>]
 ```
 
-`<本 skill 安装目录>` 即本 SKILL.md 所在目录（如 `~/.claude/skills/awesome-novel/`、`~/.config/opencode/skills/awesome-novel/`、`~/.codex/skills/awesome-novel/`、`~/.zcode/skills/awesome-novel/`、`~/.dsh/skills/awesome-novel/`）。AI 用绝对路径调用，避免在项目目录找不到 `tools/init.py`。
+`<本 skill 安装目录>` 即本 SKILL.md 所在目录（如 `~/.claude/skills/awesome-novel/`、`~/.config/opencode/skills/awesome-novel/`、`~/.codex/skills/awesome-novel/`、`~/.zcode/skills/awesome-novel/`、`~/.dsh/skills/awesome-novel/`、`~/.grok/skills/awesome-novel/`）。AI 用绝对路径调用，避免在项目目录找不到 `tools/init.py`。
 
 **禁止以任何理由跳过 init.py：** 手动创建目录、复制模板、直接调用 agent 都属于违规行为。`init.py` 是初始化入口，必须执行且完整运行。
 
 `init.py` 会：
 1. 选题材
 2. 创建项目骨架（settings/、volumes/、chapters/、prompts/、archives/）
-3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode / dsh 不部署 agents，agents 即 `.reasonix/skills/` / `.zcode/skills/` / `.dsh/skills/`；Codex → `.codex/agents/*.toml`）
-4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/` / `.codex/knowledge/` / `.zcode/knowledge/` / `.dsh/knowledge/`）
+3. 部署 agent/skill 到当前平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode / dsh 不部署 agents，agents 即 `.reasonix/skills/` / `.zcode/skills/` / `.dsh/skills/`；Codex → `.codex/agents/*.toml`；Grok Build → `.grok/agents/*.md`）
+4. 按题材继承反 AI 规则和文风偏好到平台 knowledge 目录（`.claude/knowledge/` / `.opencode/knowledge/` / `.reasonix/knowledge/` / `.codex/knowledge/` / `.zcode/knowledge/` / `.dsh/knowledge/` / `.grok/knowledge/`）
 5. 按题材继承格式规范、题材案例到平台 knowledge 目录
 6. 创建空白的写作记忆文件（平台 memory 目录）
 7. 创建永久记忆占位文件（平台 knowledge 目录）
@@ -255,33 +264,38 @@ cp old/prompts/*.txt prompts/ 2>/dev/null
 ├── .agent/
 │   ├── status.md         # 进度追踪
 │   └── task/             # agent 间 order 文件
-├── .claude/             # Claude Code 用（平台一，六选一）
+├── .claude/             # Claude Code 用（平台一，七选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-├── .opencode/           # OpenCode 用（平台二，六选一）
+├── .opencode/           # OpenCode 用（平台二，七选一）
 │   ├── agents/          # Agent 定义
 │   ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
 │   └── memory/          # 写作动态记忆
-├── .reasonix/           # Reasonix 用（平台三，六选一）
+├── .reasonix/           # Reasonix 用（平台三，七选一）
     ├── skills/          # 11 个 SKILL.md（agents 即 skills）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
-├── .codex/              # Codex 用（平台四，六选一）
+├── .codex/              # Codex 用（平台四，七选一）
     ├── agents/          # 9 个自定义 agent（TOML）
     ├── skills/          # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
-├── .zcode/              # ZCode 用（平台五，六选一）
+├── .zcode/              # ZCode 用（平台五，七选一）
     ├── skills/          # 11 个 SKILL.md（agents 即 skills）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
-└── .dsh/                # DeepSeek Harness 用（平台六，六选一）
+├── .dsh/                # DeepSeek Harness 用（平台六，七选一）
     ├── skills/          # 11 个 SKILL.md（agents 即 skills）
+    ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
+    └── memory/          # 写作动态记忆
+└── .grok/               # Grok Build 用（平台七，七选一）
+    ├── agents/          # 9 个自定义 agent（Markdown）
+    ├── skills/          # 独立交互工具（memory-recording、roleplay-sandbox）
     ├── knowledge/       # 反 AI 规则、文风偏好、永久记忆、格式规范
     └── memory/          # 写作动态记忆
 ```
-> 实际项目只生成六选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` / `.dsh/` 不会同时存在。
+> 实际项目只生成七选一的一套平台目录（由 `init.py --platform` 决定），`.claude/` / `.opencode/` / `.reasonix/` / `.codex/` / `.zcode/` / `.dsh/` / `.grok/` 不会同时存在。
 
 ## Agent 协作架构
 
@@ -299,13 +313,13 @@ novel-agent（总指挥）
   └─ 归档完成 → 卷完成判定 → 下一章 / 卷 N+1 / 完本
 ```
 
-各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode / dsh → `.reasonix/skills/` / `.zcode/skills/` / `.dsh/skills/`；Codex → `.codex/agents/*.toml`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
+各 agent 定义在平台约定目录（Claude Code → `.claude/agents/`；OpenCode → `.opencode/agents/`；Reasonix / ZCode / dsh → `.reasonix/skills/` / `.zcode/skills/` / `.dsh/skills/`；Codex → `.codex/agents/*.toml`；Grok Build → `.grok/agents/*.md`），skill SOP 在 `skills/`。agent 间通过 `.agent/task/*-order.md` 文件通信。
 
 **可选工具：** 剧情推演沙盘（`skills/roleplay-sandbox.md`）是独立的交互式工具，不在 agent 调度链中。作者卡剧情时主动调用，产出推演记录（`sandbox/`）供编写章纲时参考。
 
 **调度规则：** novel-agent 是唯一调度者，只写 order 文件 + 调用子 agent。所有内容创作（卷纲/章纲/提示词/正文）、设定维护、归档更新均由子 agent 完成，novel-agent 不得越权代劳。子 agent 完成任务后把 order 覆盖为 `status: DONE`（不删除文件），novel-agent 检测到 DONE 即确认完成。
 
-**重要：novel-agent 是顶层入口，通过 `@novel-agent`（Claude Code / OpenCode / Codex）或 ZCode 的 skill 自动发现加载进主 agent，禁止通过 Agent 工具将 novel-agent 作为 subagent 调度。** 主 agent 加载 novel-agent 定义后即扮演总指挥角色，拥有完整的 Agent 工具权限来调度子 agent。如果 novel-agent 被作为 subagent 派出，它将失去 Agent 工具调用能力，导致调度链断裂。
+**重要：novel-agent 是顶层入口，通过 `@novel-agent`（Claude Code / OpenCode / Codex）或 ZCode / Grok Build 的 skill 自动发现加载进主 agent，禁止通过 Agent / spawn_subagent 将 novel-agent 作为 subagent 调度。** 主 agent 加载 novel-agent 定义后即扮演总指挥角色，拥有完整的调度权限。如果 novel-agent 被作为 subagent 派出，它将失去再派子 agent 的能力（Grok 深度上限为 1），导致调度链断裂。
 
 ## 工具契约
 

--- a/install.ps1
+++ b/install.ps1
@@ -16,7 +16,7 @@
 
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet("claude-code", "opencode", "codex", "zcode", "dsh", "hermes", "openclaw", "deepseek-tui")]
+    [ValidateSet("claude-code", "opencode", "codex", "zcode", "dsh", "grok", "hermes", "openclaw", "deepseek-tui")]
     [string]$Platform
 )
 
@@ -47,6 +47,9 @@ switch ($Platform) {
     "dsh" {
         $DEST_DIR = Join-Path $HOME_DIR ".dsh/skills/awesome-novel"
     }
+    "grok" {
+        $DEST_DIR = Join-Path $HOME_DIR ".grok/skills/awesome-novel"
+    }
 }
 
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -63,9 +66,9 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# pyyaml 门槛：opencode / codex / zcode / dsh 的 agent/skill 转换依赖 pyyaml（与
+# pyyaml 门槛：opencode / codex / zcode / dsh / grok 的 agent/skill 转换依赖 pyyaml（与
 # tools/platforms.py ensure_yaml 的运行时规则对齐）；claude-code 纯复制不转换，不需要。
-if ($Platform -in @("opencode", "codex", "zcode", "dsh")) {
+if ($Platform -in @("opencode", "codex", "zcode", "dsh", "grok")) {
     & $PY_BIN (Join-Path $SCRIPT_DIR "tools/check-yaml.py") $Platform
     if ($LASTEXITCODE -ne 0) {
         Write-Host "安装中止：缺少 pyyaml。请先执行 pip install pyyaml 后重试。"

--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ set -e
 
 usage() {
     echo "用法: $0 <平台>"
-    echo "平台: claude-code, opencode, codex, zcode, dsh, hermes, openclaw, deepseek-tui"
+    echo "平台: claude-code, opencode, codex, zcode, dsh, grok, hermes, openclaw, deepseek-tui"
     exit 1
 }
 
@@ -56,6 +56,9 @@ case "$PLATFORM" in
     dsh)
         SKILLS_DIR="$HOME/.dsh/skills"
         ;;
+    grok)
+        SKILLS_DIR="$HOME/.grok/skills"
+        ;;
     *)
         echo "不支持的平台: $PLATFORM"
         usage
@@ -81,12 +84,12 @@ if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-python.py"; then
     exit 1
 fi
 
-# pyyaml 门槛：opencode / codex / zcode 的 agent/skill 转换依赖 pyyaml（与
+# pyyaml 门槛：opencode / codex / zcode / dsh / grok 的 agent/skill 转换依赖 pyyaml（与
 # tools/platforms.py ensure_yaml 的运行时规则对齐）；claude 平台纯复制不转换、
 # hermes/openclaw/deepseek-tui 未走转换，均不需要。缺失时同样在任何目录创建/
 # 删除前 fail-fast，而不是等 init.py / sync-project.py 执行时才报错。
 case "$PLATFORM" in
-    opencode|codex|zcode|dsh)
+    opencode|codex|zcode|dsh|grok)
         if ! "$PY_BIN" "$SCRIPT_DIR/tools/check-yaml.py" "$PLATFORM"; then
             echo "安装中止：缺少 pyyaml。请先执行 pip install pyyaml（系统 Python 权限受限时可用 pip install --user pyyaml），再重试。"
             exit 1

--- a/knowledge/format-specs/memory-format-spec.md
+++ b/knowledge/format-specs/memory-format-spec.md
@@ -18,7 +18,7 @@
     └── permanent-memory.md          # 永久记忆（从 memory/ 晋升的高频条目）
 ```
 
-> 平台目录由 init.py 按 `--platform` 决定：Claude Code → `.claude/`、OpenCode → `.opencode/`、Reasonix → `.reasonix/`、Codex → `.codex/`、ZCode → `.zcode/`、dsh → `.dsh/`。
+> 平台目录由 init.py 按 `--platform` 决定：Claude Code → `.claude/`、OpenCode → `.opencode/`、Reasonix → `.reasonix/`、Codex → `.codex/`、ZCode → `.zcode/`、dsh → `.dsh/`、Grok Build → `.grok/`。
 
 ## 二、文件头
 

--- a/skill.json
+++ b/skill.json
@@ -1,7 +1,7 @@
 {
   "name": "awesome-novel",
   "version": "4.19.0",
-  "description": "和 AI 协作写小说的工作流系统。从世界观搭建到角色塑造，从章节规划到正文写作，支持 Codex、Claude Code、OpenCode、Reasonix、ZCode 和 DeepSeek Harness（dsh）。",
+  "description": "和 AI 协作写小说的工作流系统。从世界观搭建到角色塑造，从章节规划到正文写作，支持 Codex、Claude Code、OpenCode、Reasonix、ZCode、DeepSeek Harness（dsh）和 Grok Build。",
   "author": {
     "name": "modoojunko",
     "url": "https://github.com/modoojunko"

--- a/tools/check-yaml.py
+++ b/tools/check-yaml.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """pyyaml 门槛检查（安装阶段 fail-fast 用）。
 
-opencode / codex 平台的 agent 转换依赖 pyyaml；install.sh / install.ps1
+opencode / codex / grok 等非 claude 平台的 agent 转换依赖 pyyaml；install.sh / install.ps1
 在任何目录创建/删除前调用本脚本，缺失时立即中止，而不是等 init.py /
 sync-project.py 执行时才报错。claude 平台纯复制不转换，无需本检查。
 

--- a/tools/init.py
+++ b/tools/init.py
@@ -2,7 +2,7 @@
 """
 awesome-novel-agent 项目初始化工具
 
-用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix|codex|zcode|dsh>]
+用法: python init.py [project-path] [--genre <编号>] [--platform <claude|opencode|reasonix|codex|zcode|dsh|grok>]
 
 平台缺省：--platform > NOVEL_PLATFORM > SKILL_HOME 路径识别 > claude。
 
@@ -109,7 +109,7 @@ def main():
         a = args[i]
         if a == "--platform":
             if i + 1 >= len(args) or args[i + 1].startswith("--"):
-                print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode|dsh）")
+                print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode|dsh|grok）")
                 sys.exit(1)
             platform_override = args[i + 1]
             i += 2
@@ -168,14 +168,14 @@ def main():
     # Step 2: 创建骨架
     create_skeleton(project_path, platform)
 
-    # Step 3: 部署 agent 定义（codex 为 TOML 转换产物，reasonix/zcode agents 即 skills）
+    # Step 3: 部署 agent 定义（codex 为 TOML 转换产物，reasonix/zcode/dsh agents 即 skills）
     if platform.key == "codex":
         deploy_codex_agents(project_path, SKILL_HOME, platform)
     else:
         deploy_agents(project_path, platform)
 
-    # Step 3.5: 部署平台 skills（reasonix/zcode/dsh 生成 11 个 SKILL.md；codex 只部署独立工具）
-    if platform.key == "codex":
+    # Step 3.5: 部署平台 skills（reasonix/zcode/dsh 生成 11 个 SKILL.md；codex/grok 只部署独立工具）
+    if platform.key in ("codex", "grok"):
         deploy_codex_skills(project_path, SKILL_HOME, platform)
     else:
         deploy_inline_skills(project_path, SKILL_HOME, platform)   # 非 inline 平台内部自跳过
@@ -210,6 +210,8 @@ def main():
         print("在 ZCode 中打开项目目录，说“帮我写本小说”或调用 novel-agent skill 开始写作")
     elif platform.key == "dsh":
         print("在 DeepSeek Harness（dsh）中打开项目目录，说“帮我写本小说”或调用 novel-agent skill 开始写作")
+    elif platform.key == "grok":
+        print("在 Grok Build 中打开项目目录，输入 /awesome-novel 或说“帮我写本小说”开始写作")
     else:
         print("在 Reasonix 中运行 `reasonix code`，然后调用 @novel-agent 开始写作")
 
@@ -263,8 +265,9 @@ def _rewrite_template_refs(text: str, platform: Platform) -> str:
     elif platform.key == "codex":
         text = text.replace(".claude/agents/", ".codex/agents/")
         text = text.replace(".opencode/agents/", ".codex/agents/")
-    else:  # opencode
+    else:  # opencode / grok 等独立 agents 目录
         text = text.replace(".claude/agents/", f"{platform.root}/agents/")
+        text = text.replace(".opencode/agents/", f"{platform.root}/agents/")
     return rewrite_refs(text, platform)
 
 
@@ -338,7 +341,6 @@ def deploy_agents(project_path: Path, platform: Platform):
         print(f"  ℹ️  {platform.label} 平台不部署 agent 定义（agents 即 {platform.root}/skills/）")
         return
     agent_dir.mkdir(parents=True, exist_ok=True)
-    is_opencode = platform.key == "opencode"
     for item in SOURCE_AGENTS.rglob("*"):
         if item.is_file() and item.suffix == ".md":
             rel_path = item.relative_to(SOURCE_AGENTS)
@@ -347,9 +349,8 @@ def deploy_agents(project_path: Path, platform: Platform):
             if not dest.resolve().is_relative_to(agent_dir.resolve()):
                 continue
             dest.parent.mkdir(parents=True, exist_ok=True)
-            content = item.read_text(encoding="utf-8")
-            if is_opencode:
-                content = convert_agent_to_platform(content, platform)
+            content = convert_agent_to_platform(
+                item.read_text(encoding="utf-8"), platform, SKILL_HOME)
             dest.write_text(content, encoding="utf-8")
     print(f"  ✅ 已部署 agent 定义到 {agent_dir}")
 

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -12,11 +12,13 @@ init.py / sync-project.py 共用本模块完成平台检测、目录派发、引
   - dsh      → .dsh/      agents=None（agents 即 skills，DeepSeek Harness 无项目级
                           agents 目录，.dsh/skills 为其项目级 skill 根）, skills=skills,
                           knowledge, memory
+  - grok     → .grok/     agents=agents（Markdown 转换产物，Grok Build 原生发现路径）,
+                          skills=skills, knowledge, memory
 
 扩展新平台（除 PLATFORMS 加一行外，按目录约定二选一）：
   - agents 即 skills 型：_DISPATCH_SECTIONS 加调度适配段 + _convert_standalone_skill
     的 description 后缀，deploy_inline_skills 自动覆盖
-  - 独立 agents 目录型：仿 convert_to_opencode/convert_to_codex 写转换器，
+  - 独立 agents 目录型：仿 convert_to_opencode/convert_to_codex/convert_to_grok 写转换器，
     并在 init.main 与 sync-project.sync_agents/sync_skills 各接一行分发
 
 模块名用 platforms（复数）是刻意避开标准库 platform（单数）同名冲突。
@@ -34,7 +36,7 @@ from style_common import frontmatter_text, split_frontmatter   # 单源 frontmat
 
 @dataclass(frozen=True)
 class Platform:
-    key: str                 # "claude" | "opencode" | "reasonix"
+    key: str                 # "claude" | "opencode" | "reasonix" | "grok"
     label: str               # 显示名
     root: str                # 平台根目录，如 ".reasonix"
     agents: str | None       # agents 子目录；reasonix 为 None（agents 即 skills）
@@ -73,6 +75,8 @@ PLATFORMS = {
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=(".zcode",)),
     "dsh":      Platform("dsh", "DeepSeek Harness", ".dsh", agents=None,
                          skills="skills", knowledge="knowledge", memory="memory", detect_keywords=(".dsh",)),
+    "grok":     Platform("grok", "Grok Build", ".grok", agents="agents",
+                         skills="skills", knowledge="knowledge", memory="memory", detect_keywords=(".grok",)),
 }
 
 
@@ -419,6 +423,7 @@ def convert_agent_to_platform(text: str, platform: Platform,
 
     - opencode: frontmatter → permission 格式 + 引用改写
     - codex: → TOML（SOP 内联需 skill_home；convert_to_codex 内部已含引用改写）
+    - grok: → Grok Build agent Markdown（SOP 内联需 skill_home；convert_to_grok 内部已含引用改写）
     - 其余平台（claude）: 原样（纯复制）
     """
     if platform.key == "opencode":
@@ -427,6 +432,10 @@ def convert_agent_to_platform(text: str, platform: Platform,
         if skill_home is None:
             raise ValueError("codex 平台 agent 转换需要 skill_home（SOP 内联）")
         return convert_to_codex(text, skill_home)
+    if platform.key == "grok":
+        if skill_home is None:
+            raise ValueError("grok 平台 agent 转换需要 skill_home（SOP 内联）")
+        return convert_to_grok(text, skill_home)
     return text
 
 
@@ -574,6 +583,140 @@ def convert_to_codex(text: str, skill_home: Path) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------
+# Grok Build agent 转换（Claude Code agent frontmatter → Grok .grok/agents/*.md）
+# Grok 发现路径：项目 .grok/agents/*.md；调度工具：spawn_subagent（深度上限 1）
+# ---------------------------------------------------------------
+
+_GROK_TOOL_MAP = {
+    "Read": "read_file",
+    "Write": "write",
+    "Edit": "search_replace",
+    "Glob": "list_dir",
+    "Grep": "grep",
+    "Agent": "spawn_subagent",   # Claude Code Agent 工具 ↔ Grok spawn_subagent
+    "Bash": "run_terminal_command",
+}
+
+_GROK_DISPATCH_BAN = """## 调度权限硬约束（最高优先级，先于本文件其余一切指令）
+
+你是执行型子 agent，没有任何调度权。**禁止使用 `spawn_subagent` 工具派生子 agent**
+（包括派发与自己同名的 agent，禁止任何形式的递归派生）。Grok Build 的子代理深度上限为 1，
+即便调用也会失败；这条禁令不因工具可见而失效。
+
+同时禁止：
+- 写 `.agent/task/` 下除本 order 以外的任何文件
+- 写 `.agent/status.md` 的 `phase` / `current_step` / `last_volume_completed` 字段
+  （这些字段只有 novel-agent 能写）
+- 代替 novel-agent 推进流水线（写新 order、更新 phase）
+
+你只做：
+1. 读取 order 文件，执行其中指定的任务
+2. 写 order 的 `outputs` 指向的文件
+3. 完成后把 order 的 `status` 覆盖为 `DONE` 并结束
+
+任务需要其他 agent 协作（如发现需要新增设定/归档/评审）时，不要自己调度——
+在回复中明确告诉 novel-agent"下一步应调度谁、为什么"，由 novel-agent 调度。
+
+工具对应：创建/覆盖文件用 `write`，局部修改用 `search_replace`，列目录用 `list_dir`，搜索用 `grep`。"""
+
+
+def _yaml_quote(s: str) -> str:
+    """YAML 双引号标量转义。"""
+    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def convert_to_grok(text: str, skill_home: Path) -> str:
+    """Claude Code agent frontmatter → Grok Build 项目级 agent Markdown。
+
+    - 必填字段：name / description（Grok 官方约定）
+    - tools：YAML 列表，映射为 Grok 规范名；子 agent 丢弃 spawn_subagent
+    - disallowedTools：子 agent 禁止 spawn_subagent
+    - skills：Claude 的 path 对象列表与 Grok 的 skill 名列表不兼容，SOP 内联进正文后丢弃
+    - 其余 Claude 私有字段（role/react/memory/knowledge）丢弃，避免 Grok 解析失败
+    - novel-agent 注入 spawn_subagent 调度适配段；子 agent 注入调度硬约束
+    - 路径改写：.claude/knowledge、.claude/memory → .grok/ 对应目录
+    """
+    data, _body = split_frontmatter(text)
+    if not data:
+        return rewrite_refs(text, PLATFORMS["grok"])
+
+    name = str(data.get("name", "unknown")).strip()
+    desc = str(data.get("description", "") or "").strip()
+
+    tools_raw = str(data.get("tools", "") or "")
+    allowed = []
+    for t in tools_raw.split(","):
+        t = t.strip()
+        if not t:
+            continue
+        mapped = _GROK_TOOL_MAP.get(t, t)
+        if name != "novel-agent" and mapped == "spawn_subagent":
+            continue
+        if mapped not in allowed:
+            allowed.append(mapped)
+
+    body = _body.strip()
+    if name == "novel-agent":
+        body += (
+            "\n\n## Grok Build 调度适配（本环境无 Agent 工具）\n"
+            "在 Grok Build 环境调度子 agent 用 `spawn_subagent` 工具：\n"
+            f"- 子 agent 名即 `.grok/agents/` 下的 Markdown 名（{' / '.join(SUBAGENT_NAMES)}）\n"
+            "- 调用 `spawn_subagent(subagent_type=\"<子agent名>\", prompt=<order 路径与任务要求>, "
+            "isolation=\"none\")`\n"
+            "- isolation 必须是 none（共享工作区，子 agent 写回同一项目）；禁止 worktree\n"
+            "- 把 order 文件路径与任务要求写进 prompt；order 文件协议（status: DONE）不变\n"
+            "- 一次只调度一个任务，等 DONE 后再调度下一个；禁止把 novel-agent 本身作为子 agent 调度\n"
+            "- 你必须在**主会话**中运行：Grok 子代理不能再派子代理（深度上限 1），"
+            "novel-agent 若被 spawn 为子代理，调度链会断裂\n"
+            "- 工具对应：读文件 `read_file`，写/覆盖 `write`，搜索 `grep`，列目录 `list_dir`\n"
+        )
+    else:
+        body = _GROK_DISPATCH_BAN + "\n\n" + body
+
+    if allowed:
+        if name == "novel-agent":
+            body += (
+                "\n\n（自动生成）本 agent 声明的工具范围："
+                + "、".join(allowed)
+                + "。你是唯一调度者，spawn_subagent 只用于调度子 agent，禁止派生 novel-agent 自身。"
+            )
+        else:
+            body += (
+                "\n\n（自动生成）本 agent 声明的工具范围："
+                + "、".join(allowed)
+                + "。子 agent 禁止 spawn_subagent。"
+            )
+
+    sop_sections = []
+    for rel in _agent_skill_paths(data):
+        sop = skill_home / rel
+        if sop.exists():
+            sop_sections.append(
+                f"\n---\n\n## 执行 SOP：{sop.name}\n\n{sop.read_text(encoding='utf-8').strip()}"
+            )
+    instructions = body + "\n".join(sop_sections)
+    instructions = rewrite_refs(instructions, PLATFORMS["grok"])
+
+    fm_lines = [
+        "---",
+        f"name: {name}",
+        f"description: {_yaml_quote(desc)}",
+    ]
+    if allowed:
+        fm_lines.append("tools:")
+        for t in allowed:
+            fm_lines.append(f"  - {t}")
+    if name != "novel-agent":
+        fm_lines.append("disallowedTools:")
+        fm_lines.append("  - spawn_subagent")
+        fm_lines.append("agentsMd: false")
+    else:
+        fm_lines.append("agentsMd: true")
+    fm_lines.append("---")
+    return "\n".join(fm_lines) + "\n\n" + instructions + "\n"
+
+
 def deploy_codex_agents(project: Path, skill_home: Path, platform: Platform) -> None:
     """生成 <project>/<platform.root>/agents/<name>.toml（9 个），引用改写为平台路径。
 
@@ -617,12 +760,12 @@ def _convert_codex_inline_skill(text: str, name: str) -> str:
 
 
 def deploy_codex_skills(project: Path, skill_home: Path, platform: Platform) -> None:
-    """生成独立交互工具为 Codex skill（<project>/<platform.root>/skills/<name>/SKILL.md）。
+    """生成独立交互工具为 skill（<project>/<platform.root>/skills/<name>/SKILL.md）。
 
-    仅 codex 平台调用。9 个 agent 走 .codex/agents/*.toml（deploy_codex_agents），
-    此处只部署不进调度链的独立工具（memory-recording、roleplay-sandbox）。
+    codex / grok 调用。9 个 agent 走独立 agents 目录，此处只部署不进调度链的
+    独立工具（memory-recording、roleplay-sandbox）。
     """
-    if platform.key != "codex":
+    if platform.key not in ("codex", "grok"):
         return
     skills_dir = skill_home / "skills"
     target = platform.skills_dir(project)
@@ -633,8 +776,10 @@ def deploy_codex_skills(project: Path, skill_home: Path, platform: Platform) -> 
         sf = skills_dir / f"{skill_name}.md"
         if sf.exists():
             body = _convert_codex_inline_skill(sf.read_text(encoding="utf-8"), skill_name)
+            if platform.key == "grok":
+                body = body.replace("Codex skill", "Grok Build skill")
             body = rewrite_refs(body, platform)
             skill_dir = target / skill_name
             skill_dir.mkdir(parents=True, exist_ok=True)
             (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
-    print(f"  ✅ 已部署 Codex 独立工具 skill 到 {target}")
+    print(f"  ✅ 已部署 {platform.label} 独立工具 skill 到 {target}")

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -594,7 +594,7 @@ _GROK_TOOL_MAP = {
     "Edit": "search_replace",
     "Glob": "list_dir",
     "Grep": "grep",
-    "Agent": "spawn_subagent",   # Claude Code Agent 工具 ↔ Grok spawn_subagent
+    "Agent": "Agent",            # frontmatter 指令；模型调用名仍是 spawn_subagent
     "Bash": "run_terminal_command",
 }
 
@@ -630,8 +630,8 @@ def convert_to_grok(text: str, skill_home: Path) -> str:
     """Claude Code agent frontmatter → Grok Build 项目级 agent Markdown。
 
     - 必填字段：name / description（Grok 官方约定）
-    - tools：YAML 列表，映射为 Grok 规范名；子 agent 丢弃 spawn_subagent
-    - disallowedTools：子 agent 禁止 spawn_subagent
+    - tools：YAML 列表，Agent 保留为 Grok 的子代理授权指令
+    - disallowedTools：子 agent 用 Agent 禁止子代理工具族
     - skills：Claude 的 path 对象列表与 Grok 的 skill 名列表不兼容，SOP 内联进正文后丢弃
     - 其余 Claude 私有字段（role/react/memory/knowledge）丢弃，避免 Grok 解析失败
     - novel-agent 注入 spawn_subagent 调度适配段；子 agent 注入调度硬约束
@@ -709,7 +709,7 @@ def convert_to_grok(text: str, skill_home: Path) -> str:
             fm_lines.append(f"  - {t}")
     if name != "novel-agent":
         fm_lines.append("disallowedTools:")
-        fm_lines.append("  - spawn_subagent")
+        fm_lines.append("  - Agent")
         fm_lines.append("agentsMd: false")
     else:
         fm_lines.append("agentsMd: true")

--- a/tools/platforms.py
+++ b/tools/platforms.py
@@ -651,7 +651,7 @@ def convert_to_grok(text: str, skill_home: Path) -> str:
         if not t:
             continue
         mapped = _GROK_TOOL_MAP.get(t, t)
-        if name != "novel-agent" and mapped == "spawn_subagent":
+        if name != "novel-agent" and mapped == "Agent":
             continue
         if mapped not in allowed:
             allowed.append(mapped)

--- a/tools/sync-project.py
+++ b/tools/sync-project.py
@@ -69,7 +69,7 @@ def main():
         if idx + 1 < len(sys.argv) and not sys.argv[idx + 1].startswith("--"):
             platform_override = sys.argv[idx + 1]
         else:
-            print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode）")
+            print("错误: --platform 需要一个平台名（claude|opencode|reasonix|codex|zcode|dsh|grok）")
             sys.exit(1)
     platform_override = platform_override or os.environ.get("NOVEL_PLATFORM")
     try:
@@ -219,7 +219,7 @@ def check_freshness(project: Path, platform: Platform):
         sys.exit(0)
     else:
         changes = find_changes(project, platform)
-        if not changes and platform.key in ("reasonix", "codex", "zcode", "dsh"):
+        if not changes and platform.key in ("reasonix", "codex", "zcode", "dsh", "grok"):
             print("有更新可用（源文件变化，平台派生产物由同步时重新生成）。")
         elif not changes:
             # 指纹含风格资产（writing-style.md + style-profiles/**，line 143-149）而 find_changes 只扫
@@ -259,7 +259,7 @@ def find_changes(project: Path, platform: Platform) -> list[str]:
             continue
         if platform.key in ("reasonix", "zcode", "dsh") and name == "skills":
             continue  # 派生产物靠源指纹检测，同步时重新生成
-        if platform.key == "codex" and name in ("agents", "skills"):
+        if platform.key in ("codex", "grok") and name in ("agents", "skills"):
             continue  # TOML/SKILL.md 是派生产物，靠源指纹检测，同步时重新生成
         for item in sorted(src_dir.rglob("*.md")):
             if item.name == ".gitkeep":
@@ -327,8 +327,8 @@ def sync_agents(project_path: Path, platform: Platform) -> int:
         print(f"  [i] {platform.label} 平台无 agents 目录（agents 即 skills）")
         return 0
     target.mkdir(parents=True, exist_ok=True)
-    if platform.key in ("opencode", "codex"):
-        # 转换产物（opencode: permission 格式 + 引用改写；codex: TOML），
+    if platform.key in ("opencode", "codex", "grok"):
+        # 转换产物（opencode: permission 格式 + 引用改写；codex: TOML；grok: agent Markdown），
         # 转换逻辑单源见 platforms.convert_agent_to_platform（与 init.deploy_agents 一致）
         count = 0
         for item in sorted(AGENT_DIR.rglob("*.md")):
@@ -358,10 +358,10 @@ def sync_skills(project_path: Path, platform: Platform) -> int:
         n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
         print(f"  [OK] {platform.key} skills: {n} 个 SKILL.md 已重新生成")
         return n
-    if platform.key == "codex":
+    if platform.key in ("codex", "grok"):
         deploy_codex_skills(project_path, SKILL_HOME, platform)
         n = len(list(platform.skills_dir(project_path).rglob("SKILL.md")))
-        print(f"  [OK] codex skills: {n} 个 SKILL.md 已重新生成")
+        print(f"  [OK] {platform.key} skills: {n} 个 SKILL.md 已重新生成")
         return n
     target = platform.skills_dir(project_path)
     target.mkdir(parents=True, exist_ok=True)

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -56,6 +56,7 @@ def test_detect():
     check("override=claude", p.detect_platform(Path("d:/x"), "claude").key == "claude")
     check("override=zcode", p.detect_platform(Path("d:/x"), "zcode").key == "zcode")
     check("override=dsh", p.detect_platform(Path("d:/x"), "dsh").key == "dsh")
+    check("override=grok", p.detect_platform(Path("d:/x"), "grok").key == "grok")
     check("path reasonix",
           p.detect_platform(Path("d:/proj/.reasonix/skills/awesome-novel")).key == "reasonix")
     check("path opencode",
@@ -64,6 +65,8 @@ def test_detect():
           p.detect_platform(Path("d:/proj/.zcode/skills/awesome-novel")).key == "zcode")
     check("path dsh",
           p.detect_platform(Path("d:/proj/.dsh/skills/awesome-novel")).key == "dsh")
+    check("path grok",
+          p.detect_platform(Path("d:/proj/.grok/skills/awesome-novel")).key == "grok")
     check("default claude",
           p.detect_platform(Path("d:/code/awesome-novel-agent")).key == "claude")
 
@@ -89,6 +92,10 @@ def test_rewrite():
     check("dsh 改写两处",
           out == "先 Read `.dsh/knowledge/anti-ai.md` 和 `.dsh/memory/volume-memory.md`",
           out)
+    out = p.rewrite_refs(text, p.PLATFORMS["grok"])
+    check("grok 改写两处",
+          out == "先 Read `.grok/knowledge/anti-ai.md` 和 `.grok/memory/volume-memory.md`",
+          out)
 
 
 def test_config():
@@ -109,6 +116,10 @@ def test_config():
     check("dsh agents=None", p.PLATFORMS["dsh"].agents_dir(Path("P")) is None)
     check("dsh skills 路径",
           p.PLATFORMS["dsh"].skills_dir(Path("P")) == Path("P") / ".dsh" / "skills")
+    check("grok agents 路径",
+          p.PLATFORMS["grok"].agents_dir(Path("P")) == Path("P") / ".grok" / "agents")
+    check("grok skills 路径",
+          p.PLATFORMS["grok"].skills_dir(Path("P")) == Path("P") / ".grok" / "skills")
     check("unknown key 抛错", _raises(p.platform_from_key, "bad-key"))
     check("检测优先显式覆盖", p.detect_platform(Path("d:/x/.reasonix/skills"), "claude").key == "claude")
     check("检测 codex 路径",
@@ -117,8 +128,12 @@ def test_config():
           p.detect_platform(Path("d:/x/.zcode/skills/awesome-novel")).key == "zcode")
     check("检测 dsh 路径",
           p.detect_platform(Path("d:/x/.dsh/skills/awesome-novel")).key == "dsh")
+    check("检测 grok 路径",
+          p.detect_platform(Path("d:/x/.grok/skills/awesome-novel")).key == "grok")
     check("检测 claude 路径含 codex 子串回落 claude",
           p.detect_platform(Path("/Users/codex-dev/.claude/skills/awesome-novel")).key == "claude")
+    check("检测 claude 路径含 grok 子串回落 claude",
+          p.detect_platform(Path("/Users/grok-dev/.claude/skills/awesome-novel")).key == "claude")
 
 
 def test_yaml_precheck():
@@ -142,6 +157,8 @@ def test_yaml_precheck():
               _raises_system_exit(p.ensure_yaml, p.PLATFORMS["reasonix"]))
         check("缺 yaml 时 zcode 报错",
               _raises_system_exit(p.ensure_yaml, p.PLATFORMS["zcode"]))
+        check("缺 yaml 时 grok 报错",
+              _raises_system_exit(p.ensure_yaml, p.PLATFORMS["grok"]))
     finally:
         builtins.__import__ = real_import
 
@@ -263,6 +280,7 @@ def test_init_layout():
         "reasonix": (["skills", "knowledge", "memory"], [".claude"]),
         "codex":    (["agents", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
         "zcode":    (["skills", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
+        "grok":     (["agents", "knowledge", "memory"], [".claude", ".opencode", ".reasonix"]),
     }
     for key, (subs, absents) in expect_map.items():
         with tempfile.TemporaryDirectory() as td:
@@ -452,6 +470,52 @@ def test_init_layout():
         check("dsh CLAUDE.md 无 .claude/agents",
               ".claude/agents" not in cl and ".dsh/skills/" in cl, cl[:200])
 
+    # grok agent Markdown + skill + 模板
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "grok")
+        n = len(list((tmp / ".grok/agents").glob("*.md")))
+        check("grok agents 数量=9", n == 9, f"实际 {n}")
+        w = (tmp / ".grok/agents/writer.md").read_text(encoding="utf-8")
+        fm = w.split("---", 2)[1]
+        check("grok writer frontmatter",
+              "name: writer" in fm and "description:" in fm
+              and "read_file" in fm and "write" in fm
+              and "spawn_subagent" in fm and "disallowedTools:" in fm, fm[:400])
+        check("grok writer 引用改写",
+              ".grok/knowledge/" in w and ".claude/knowledge/" not in w)
+        check("grok writer SOP 内联", "执行 SOP：writing-execution.md" in w)
+        check("grok 子 agent 注入调度硬约束",
+              "调度权限硬约束" in w and "spawn_subagent" in w)
+        nv = (tmp / ".grok/agents/novel-agent.md").read_text(encoding="utf-8")
+        nfm = nv.split("---", 2)[1]
+        check("grok novel-agent 调度适配",
+              "spawn_subagent" in nv and ".grok/agents/" in nv
+              and "Grok Build 调度适配" in nv)
+        check("grok novel-agent 持有 spawn_subagent",
+              "spawn_subagent" in nfm and "disallowedTools:" not in nfm, nfm[:300])
+        check("grok novel-agent 不注入禁调",
+              "调度权限硬约束" not in nv, "novel-agent 是唯一调度者，不应注入禁调")
+        all_md = "".join(
+            f.read_text(encoding="utf-8") for f in sorted((tmp / ".grok/agents").glob("*.md"))
+        )
+        check("grok 全部 agent 无 .claude 残留", ".claude" not in all_md)
+        aa = (tmp / ".grok/agents/anti-ai.md").read_text(encoding="utf-8")
+        aafm = aa.split("---", 2)[1]
+        check("grok anti-ai 保留 shell",
+              "run_terminal_command" in aafm, aafm[:300])
+        check("grok skill roleplay-sandbox",
+              (tmp / ".grok/skills/roleplay-sandbox/SKILL.md").exists())
+        check("grok skill memory-recording",
+              (tmp / ".grok/skills/memory-recording/SKILL.md").exists())
+        ag = (tmp / "AGENTS.md").read_text(encoding="utf-8")
+        check("grok AGENTS.md 指向 .grok/agents", ".grok/agents/" in ag, ag[:200])
+        cl = (tmp / "CLAUDE.md").read_text(encoding="utf-8")
+        check("grok CLAUDE.md 无 .claude/agents",
+              ".claude/agents" not in cl and ".grok/agents/" in cl, cl[:200])
+        check("grok 部署 tools/check-prose.py",
+              (tmp / ".grok/tools/check-prose.py").exists())
+
 
 # ---------------- E2E sync ----------------
 
@@ -521,6 +585,20 @@ def test_sync():
               "allowed-tools:" not in w.split("---", 2)[1]
               and ".dsh/knowledge/" in w and ".claude/" not in w)
         check("dsh sync 无 .claude", not (tmp / ".claude").exists())
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        init_project(tmp, "grok")
+        r = run([sys.executable, str(TOOLS / "sync-project.py"), str(tmp),
+                 "--platform", "grok"], cwd=str(tmp))
+        check("grok sync exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
+        w = (tmp / ".grok/agents/writer.md").read_text(encoding="utf-8")
+        check("grok sync 保持 agent Markdown",
+              "name: writer" in w and "spawn_subagent" in w
+              and ".grok/knowledge/" in w and ".claude/" not in w)
+        check("grok sync 保持 skill",
+              (tmp / ".grok/skills/roleplay-sandbox/SKILL.md").exists())
+        check("grok sync 无 .claude", not (tmp / ".claude").exists())
 
     # tools/check-prose.py 同步恢复（模拟升级：脚本被删/改旧，sync 重新部署）
     with tempfile.TemporaryDirectory() as td:

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -483,7 +483,9 @@ def test_init_layout():
         fm_data = yaml.safe_load(fm)
         check("grok writer frontmatter",
               "name: writer" in fm and "description:" in fm
-              and "read_file" in fm and "write" in fm
+              and "read_file" in fm and "write" in fm, fm[:400])
+        check("grok 子 agent 禁止且未授权 Agent",
+              "Agent" not in fm_data.get("tools", [])
               and fm_data.get("disallowedTools") == ["Agent"], fm[:400])
         check("grok 子 agent frontmatter 不使用模型调用名",
               "spawn_subagent" not in fm_data.get("tools", [])
@@ -602,9 +604,13 @@ def test_sync():
                  "--platform", "grok"], cwd=str(tmp))
         check("grok sync exit 0", r.returncode == 0, (r.stdout + r.stderr)[-400:])
         w = (tmp / ".grok/agents/writer.md").read_text(encoding="utf-8")
+        fm_data = yaml.safe_load(w.split("---", 2)[1])
         check("grok sync 保持 agent Markdown",
-              "name: writer" in w and "spawn_subagent" in w
+              fm_data.get("name") == "writer"
               and ".grok/knowledge/" in w and ".claude/" not in w)
+        check("grok sync 子 agent 禁止且未授权 Agent",
+              "Agent" not in fm_data.get("tools", [])
+              and fm_data.get("disallowedTools") == ["Agent"], str(fm_data))
         check("grok sync 保持 skill",
               (tmp / ".grok/skills/roleplay-sandbox/SKILL.md").exists())
         check("grok sync 无 .claude", not (tmp / ".claude").exists())

--- a/tools/test_platforms.py
+++ b/tools/test_platforms.py
@@ -19,6 +19,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import yaml
+
 # 强制 UTF-8 输出，避免 Windows GBK 控制台报错（AGENTS.md:79）
 for _s in (sys.stdout, sys.stderr):
     try:
@@ -478,10 +480,14 @@ def test_init_layout():
         check("grok agents 数量=9", n == 9, f"实际 {n}")
         w = (tmp / ".grok/agents/writer.md").read_text(encoding="utf-8")
         fm = w.split("---", 2)[1]
+        fm_data = yaml.safe_load(fm)
         check("grok writer frontmatter",
               "name: writer" in fm and "description:" in fm
               and "read_file" in fm and "write" in fm
-              and "spawn_subagent" in fm and "disallowedTools:" in fm, fm[:400])
+              and fm_data.get("disallowedTools") == ["Agent"], fm[:400])
+        check("grok 子 agent frontmatter 不使用模型调用名",
+              "spawn_subagent" not in fm_data.get("tools", [])
+              and "spawn_subagent" not in fm_data.get("disallowedTools", []), fm[:400])
         check("grok writer 引用改写",
               ".grok/knowledge/" in w and ".claude/knowledge/" not in w)
         check("grok writer SOP 内联", "执行 SOP：writing-execution.md" in w)
@@ -489,11 +495,14 @@ def test_init_layout():
               "调度权限硬约束" in w and "spawn_subagent" in w)
         nv = (tmp / ".grok/agents/novel-agent.md").read_text(encoding="utf-8")
         nfm = nv.split("---", 2)[1]
+        nfm_data = yaml.safe_load(nfm)
         check("grok novel-agent 调度适配",
               "spawn_subagent" in nv and ".grok/agents/" in nv
               and "Grok Build 调度适配" in nv)
-        check("grok novel-agent 持有 spawn_subagent",
-              "spawn_subagent" in nfm and "disallowedTools:" not in nfm, nfm[:300])
+        check("grok novel-agent frontmatter 启用 Agent 指令",
+              "Agent" in nfm_data.get("tools", [])
+              and "spawn_subagent" not in nfm_data.get("tools", [])
+              and "disallowedTools" not in nfm_data, nfm[:300])
         check("grok novel-agent 不注入禁调",
               "调度权限硬约束" not in nv, "novel-agent 是唯一调度者，不应注入禁调")
         all_md = "".join(


### PR DESCRIPTION
## 做什么

接入 **Grok Build** 作为第七个平台，与 Codex、dsh 共用 `platforms.py` 适配层。

个人用户可将 skill 安装到 `~/.grok/skills/awesome-novel/`，并通过 `/awesome-novel` 初始化和使用小说项目。

## 主要改动

### 平台适配

- 在 `tools/platforms.py` 注册 `grok` 平台：
  - 项目配置目录：`.grok/`
  - agent 目录：`.grok/agents/*.md`
  - 独立 skill 目录：`.grok/skills/<name>/SKILL.md`
- 新增 `convert_to_grok`：
  - 将 Claude agent frontmatter 转换为 Grok 格式
  - 将 `.claude/` 引用改写为 `.grok/`
  - 将 agent 使用的 SOP 内联到正文
  - 将工具名转换为 Grok 支持的名称
- novel-agent 使用 frontmatter 指令 `Agent` 获得子代理调度权限，正文中调用模型工具名 `spawn_subagent`
- 子 agent 的 `tools` 不包含 `Agent`，并使用 `disallowedTools: [Agent]` 明确禁止继续派发
- `memory-recording`、`roleplay-sandbox` 部署为独立 Grok skill

### 安装、初始化与同步

- `install.sh`、`install.ps1` 支持平台参数 `grok`
- 安装目标为 `~/.grok/skills/awesome-novel/`
- 安装阶段检查 Python 和 pyyaml
- `init.py --platform grok` 部署 agent、skill、knowledge、memory 和工具
- `sync-project.py` 将 Grok agents/skills 作为派生产物重新生成
- 文档、架构说明和平台元数据同步补充 Grok Build

## 评审问题修复

针对评审与复审提出的问题：

- **P1：frontmatter 中错误使用 `spawn_subagent`**
  - `_GROK_TOOL_MAP["Agent"]` 已改为保留 `Agent`
  - novel-agent 生成的 `tools` 包含 `Agent`
  - `spawn_subagent` 仅保留在正文中作为模型实际调用的工具名
- **P3：`disallowedTools: [spawn_subagent]` 无法匹配**
  - 子 agent 已改为 `disallowedTools: [Agent]`
  - Grok 会正确剥离 task 工具族，防止子 agent 继续派发
- **复审：子 agent 同时授权和禁止 `Agent`**
  - 子 agent 的工具过滤条件已改为匹配映射后的 `Agent`
  - 子 agent 的 `tools` 不再包含 `Agent`，仅保留 `disallowedTools: [Agent]` 作为明确禁令
  - init 与 sync 测试均解析 YAML frontmatter，直接断言权限关系

## 自动验证

在 WSL 2 Ubuntu 24.04 的 Linux 原生环境中执行完整检查：

- `python tools/test_platforms.py`：254 通过，0 失败
- `python tools/test_style_rules.py`：125 通过，0 失败
- `python tools/test_style_distill.py`：84 通过，0 失败
- `python tools/test_check_prose.py`：10 通过，0 失败
- Python 语法检查通过
- agent 定义与引用检查通过
- 反 AI 规则冲突检查通过
- 版本一致性检查通过

合计：**473 项通过，0 失败**。

Windows 环境下 `install.ps1 codex` 的真实安装烟雾测试也已通过。`install.sh` 已切换为 LF，并完成人工验证。

## Grok Build 真实端到端验证

已在 `D:\Chen\Book` 完成 Grok 项目初始化，并在真实 Grok Build 1.0.5 中验证：

- 用户级 `awesome-novel` skill 可以被发现
- `/awesome-novel` 可以正常加载项目
- novel-agent 成功调用 `spawn_subagent`
- 成功以 `subagent_type=updater`、`isolation=none` 派发 updater
- 子 agent 未获得二次派发权限，验证输出为 `nested_dispatch_available: false`
- 25 个非生成书稿文件哈希在验证前后完全一致
- 未出现以下警告：
  - `tools allowlist had unmappable entries`
  - `disallowedTools entry matched nothing`

## 使用方式

```bash
./install.sh grok
python ~/.grok/skills/awesome-novel/tools/init.py <小说项目路径> --platform grok
```

Windows：

```powershell
.\install.ps1 grok
python tools\init.py D:\Chen\Book --genre 1 --platform grok
```

在 Grok Build 中打开小说项目目录，输入 `/awesome-novel`，或直接说“帮我写本小说”。

## 使用约束

novel-agent 必须在主会话运行，不要通过 `spawn_subagent(subagent_type="novel-agent")` 启动，否则会形成无法继续派发的嵌套子代理。