### PR TITLE
test: AI 终端实测通过，勾选朱雀三阶段实测任务

### DIFF
--- a/openspec/changes/add-detect-loop-skill/tasks.md
+++ b/openspec/changes/add-detect-loop-skill/tasks.md
@@ -13,4 +13,5 @@
 
 - [x] 3.1 全量检查：`check-agents.py` + `check-conflicts.py` + `py_compile` + `test_platforms.py`（验证：全绿）
 - [ ] 3.2 真机演练一次：本地送检工具（用户自备）→ 走完 修最高窗→锁版→沉淀 全流程（验证：战役记录新增一轮、回归串入库、check-chapter 复跑 exit 0）
+  - 2026-08-31 已验证触发与降级语义：claude 无头会话正确识别"送检"意图、本地无工具时按 skill 优雅终止并给作者大白话说明、未越权写文件；真机外测全流程仍待作者自备检测途径
 - [x] 3.3 发版 `chore: bump version to v4.24.0`，更新 `VERSION` 与 `docs/releasenotes/releasenote-4.24.0.md`（验证：`check-version.py` 通过）

--- a/openspec/changes/add-zhuque-source-defense/tasks.md
+++ b/openspec/changes/add-zhuque-source-defense/tasks.md
@@ -18,6 +18,6 @@
 ## 4. 收尾与发版
 
 - [x] 4.1 全量检查：`check-agents.py` + `check-conflicts.py` + `py_compile` + 两个测试脚本（验证：全绿）
-- [ ] 4.2 在至少一个 AI 终端实测初始化项目并跑一次 check-chapter（验证：按仓库提交指南）
-  - 已完成本地机械验证（init 临时项目→部署产物可运行、警告正确、合并知识就位）；AI 终端实测待作者执行
+- [x] 4.2 在至少一个 AI 终端实测初始化项目并跑一次 check-chapter（验证：按仓库提交指南）
+  - 2026-08-31 claude 无头会话实测：init 临时项目→部署产物可运行；anti-ai 会话实际执行两个脚本，check-chapter exit 1 正确命中夹层硬伤、5 项警告逐条列出（详见 PR test/ai-terminal-verification）
 - [x] 4.3 发版 `chore: bump version to v4.22.0`，更新 `VERSION` 与 `docs/releasenotes/releasenote-4.22.0.md`（验证：`check-version.py` 通过）

--- a/openspec/changes/wire-source-constraints-into-pipeline/tasks.md
+++ b/openspec/changes/wire-source-constraints-into-pipeline/tasks.md
@@ -24,5 +24,6 @@
 ## 5. 收尾与发版
 
 - [x] 5.1 全量检查：`check-agents.py` + `check-conflicts.py` + `py_compile` + `test_platforms.py`（验证：全绿）
-- [ ] 5.2 至少一个 AI 终端实测：初始化新项目→走一遍 writer/prompt/anti-ai 挂接点（验证：按仓库提交指南）
+- [x] 5.2 至少一个 AI 终端实测：初始化新项目→走一遍 writer/prompt/anti-ai 挂接点（验证：按仓库提交指南）
+  - 2026-08-31 claude 无头会话实测 anti-ai 挂接点：结构热源扫描命中 4 处并单列、双脚本真实执行且交叉结论正确（check-prose 全绿/check-chapter 红=热源在结构不在词句，与设计论断一致）
 - [x] 5.3 发版 `chore: bump version to v4.23.0`，更新 `VERSION` 与 `docs/releasenotes/releasenote-4.23.0.md`（验证：`check-version.py` 通过）


### PR DESCRIPTION
## 概要

朱雀融入三阶段（v4.22.0-v4.24.0，PR #122-124）合并后的 AI 终端实测收尾：用 claude 无头会话在临时初始化项目（v4.24.0 main）里实测各挂接点，实测结果勾回三个 change 的任务清单。纯 openspec 文档改动，零代码。

## 实测记录（2026-08-31，claude CLI 无头模式）

**环境**：`init.py` 临时项目（xianxia 题材、claude 平台），验证 sandbox 三骨架、双脚本部署、anti-ai.md 合并产物均就位。

**① anti-ai 挂接点（change1 4.2 + change2 5.2）**
- 放入一篇含典型问题的测试稿（问答转述连排、夹层硬伤、尾随标签、副词堆叠、微闭环章尾）。
- claude 会话实际执行 `check-prose.py` 与 `check-chapter.py`：后者 exit 1 正确命中夹层-标签式硬伤，5 项警告（问答并段/广义夹层/尾随标签/弱化副词）逐条定位；前者词句级全绿。
- 结构热源扫描命中 4 处并单列。交叉结论与设计论断一致：**词句干净 ≠ 结构干净**，只跑词句脚本会误判此稿。
- 首轮会话无 Bash 权限时 agent 如实标注"手算预估、以脚本实跑为准"（降级语义正确）；带工具权限重跑以真实输出为准。

**② detect-loop 触发与降级（change3 3.2 部分）**
- 作者话术"送检"被正确识别为触发；本地无送检工具时按 skill 优雅终止，给作者大白话说明（外部检测需作者自备、发不发由作者定），未越权写任何文件。
- **真机外测全流程（修最高窗→锁版→沉淀）仍未做**——需作者自备检测途径，任务保持未勾。

## 测试

- [x] 三个 change `openspec validate --strict` 通过
- 其余为文档勾选，无代码改动
