### PR TITLE
fix: 部署集路径统一正斜杠，修 Windows 上孤儿检测全量误报

### DIFF
--- a/tools/check-agents.py
+++ b/tools/check-agents.py
@@ -223,7 +223,7 @@ def _deployed_knowledge_files() -> set[str] | None:
         know = fake_project / ".claude" / "knowledge"
         if not know.is_dir():
             return None
-        return {str(p.relative_to(know)) for p in know.rglob("*") if p.is_file()}
+        return {p.relative_to(know).as_posix() for p in know.rglob("*") if p.is_file()}
 
 
 def check_deployed_knowledge_refs() -> list:


### PR DESCRIPTION
## 问题

\_deployed_knowledge_files()\（tools/check-agents.py L226）用 \str(p.relative_to(know))\ 生成部署产物清单——Windows 上是反斜杠路径（\scene-craft\\dialogue\\universal.md\），而引用扫描（L372 起的正则与 agents/skills 正文）全部是正斜杠。\check_orphan_knowledge\ 的 \el in referenced\ 判定因此**在 Windows 上对一切多级目录 knowledge 文件失配**：上游树在 Windows 本机跑 \python tools/check-agents.py\ 报 96 个孤儿、exit 1，而 ubuntu CI 全绿——同一棵树、同一份代码，仅平台差异。

## 修复

\str(...)\ → \.as_posix()\，一行。Windows 与 Linux 行为对齐后：上游树孤儿告警 0（与 CI 一致），引用校验在 Windows 恢复真实效力。

## 验证

- Windows 11 + Python 3.11：上游未修树 96 问题 exit 1 → 修复后 0 问题 exit 0；
- 消费方（一个含 21 个新增 knowledge 文件的下游仓库）复跑：孤儿只报真实未接线文件，多级路径全部正确匹配。
