### PR TITLE
fix: install.ps1 补 UTF-8 BOM，修 Windows PowerShell 5.1 解析失败

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# awesome-novel-agent - AI-assisted novel writing workflow system
+﻿# awesome-novel-agent - AI-assisted novel writing workflow system
 # Copyright (C) 2026  modoojunko
 #
 # This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## 问题

install.ps1 是**无 BOM 的 UTF-8**。Windows PowerShell 5.1（系统默认 shell）对无 BOM 脚本按 ANSI/GBK 读取，脚本内的中文提示串直接引发 ParserError（\TerminatorExpectedAtEndOfString\），安装器在 Windows 上完全无法运行。ubuntu CI 因 pwsh 7 默认 UTF-8 而绿，掩盖了该问题。

## 修复

文件头补 UTF-8 BOM（内容零改动）。PS 5.1 与 pwsh 7 双通。

## 验证

Windows 11 PowerShell 5.1：\install.ps1 -Platform claude-code\ 修复前 ParserError exit 1 → 修复后 exit 0，SKILL.md + agents + tools 正常落位。
